### PR TITLE
KZN-6901 pass rest spread 'elementProps' variable from Element to user componen

### DIFF
--- a/packages/core/src/nodes/Element.tsx
+++ b/packages/core/src/nodes/Element.tsx
@@ -81,5 +81,5 @@ export function Element<T extends React.ElementType>({
     }
   });
 
-  return linkedNodeId ? <NodeElement id={linkedNodeId} /> : null;
+  return linkedNodeId ? <NodeElement id={linkedNodeId} {...elementProps} /> : null;
 }

--- a/packages/core/src/nodes/NodeElement.tsx
+++ b/packages/core/src/nodes/NodeElement.tsx
@@ -12,10 +12,10 @@ export type NodeElementProps = {
 
 export const NodeElement: React.FC<React.PropsWithChildren<
   NodeElementProps
->> = ({ id, render }) => {
+>> = ({ id, render, ...rest }) => {
   return (
     <NodeProvider id={id}>
-      <RenderNodeToElement render={render} />
+      <RenderNodeToElement render={render} {...rest} />
     </NodeProvider>
   );
 };

--- a/packages/core/src/render/DefaultRender.tsx
+++ b/packages/core/src/render/DefaultRender.tsx
@@ -6,7 +6,7 @@ import { NodeId } from '../interfaces';
 import { NodeElement } from '../nodes/NodeElement';
 import { useInternalNode } from '../nodes/useInternalNode';
 
-export const DefaultRender = () => {
+export const DefaultRender = (p) => {
   const { type, props, nodes, hydrationTimestamp } = useInternalNode(
     (node) => ({
       type: node.data.type,
@@ -29,7 +29,7 @@ export const DefaultRender = () => {
       );
     }
 
-    const render = React.createElement(type, props, children);
+    const render = React.createElement(type, { ...props, ...p }, children);
 
     if (typeof type == 'string') {
       return <SimpleElement render={render} />;
@@ -37,5 +37,5 @@ export const DefaultRender = () => {
 
     return render;
     // eslint-disable-next-line  react-hooks/exhaustive-deps
-  }, [type, props, hydrationTimestamp, nodes]);
+  }, [type, props, p, hydrationTimestamp, nodes]);
 };

--- a/packages/core/src/render/RenderNode.tsx
+++ b/packages/core/src/render/RenderNode.tsx
@@ -10,7 +10,7 @@ type RenderNodeToElementType = {
 };
 export const RenderNodeToElement: React.FC<React.PropsWithChildren<
   RenderNodeToElementType
->> = ({ render }) => {
+>> = ({ render, ...rest }) => {
   const { hidden } = useInternalNode((node) => ({
     hidden: node.data.hidden,
   }));
@@ -24,5 +24,5 @@ export const RenderNodeToElement: React.FC<React.PropsWithChildren<
     return null;
   }
 
-  return React.createElement(onRender, { render: render || <DefaultRender /> });
+  return React.createElement(onRender, { render: render || <DefaultRender {...rest} /> });
 };


### PR DESCRIPTION
## Goal
The latest version of craft broke our usage of `<Element is={Cell} {...props} />`. The additional props provided to Element are not available in the user component specified in the `is` props. These changes pass the props down through all the internal craft components so they are available in the user component.

https://kizen.atlassian.net/browse/KZN-6901