### PR TITLE
KZN-8239 update getRandomId utility to use the same size and characte…

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/prevwong/craft.js/issues"
   },
   "dependencies": {
-    "@craftjs/utils": "^0.2.0-beta.8",
+    "@craftjs/utils": "workspace:*",
     "debounce": "^1.2.0",
     "lodash": "^4.17.20",
     "tiny-invariant": "^1.0.6"

--- a/packages/utils/.npmignore
+++ b/packages/utils/.npmignore
@@ -1,4 +1,3 @@
-src
 rollup.config.js
 tsconfig.json
 nodemon.json

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,8 +4,8 @@
   "version": "0.2.0-beta.8",
   "author": "Prev Wong <prevwong@gmail.com>",
   "license": "MIT",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
   "types": "./lib/index.d.ts",
   "scripts": {
     "start": "cross-env NODE_ENV=development ../../scripts/build.sh",

--- a/packages/utils/src/getRandomId.ts
+++ b/packages/utils/src/getRandomId.ts
@@ -1,4 +1,8 @@
-import { nanoid } from 'nanoid';
+import { customAlphabet } from 'nanoid';
+
+// updated to use the same id size & character set as @kizen/page-builder in the react-app repository
+// https://github.com/kizen/react-app/blob/develop/packages/page-builder/utils/id.ts#L13
+const nanoid = customAlphabet('1234567890abcdef', 24);
 
 // By default nanoid generate an ID with 21 characters. To reduce the footprint, we default to 10 characters.
 // We have a higher probability for collisions, though
@@ -9,4 +13,4 @@ import { nanoid } from 'nanoid';
  * @param size The number of characters that are generated for the ID. Defaults to `10`
  * @returns A random id
  */
-export const getRandomId = (size: number = 10) => nanoid(size);
+export const getRandomId = () => nanoid();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@craftjs/core@workspace:packages/core"
   dependencies:
-    "@craftjs/utils": ^0.2.0-beta.8
+    "@craftjs/utils": "workspace:*"
     "@types/react": 17.0.2
     debounce: ^1.2.0
     lodash: ^4.17.20
@@ -1817,7 +1817,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@craftjs/utils@^0.2.0-beta.8, @craftjs/utils@workspace:packages/utils":
+"@craftjs/utils@^0.2.0-beta.8, @craftjs/utils@workspace:*, @craftjs/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@craftjs/utils@workspace:packages/utils"
   dependencies:


### PR DESCRIPTION
## Goal
Update the id generator so new nodes are created without underscores. This is the same id generator used in `react-app` when we reassign dynamic image node ids (https://github.com/kizen/react-app/blob/develop/packages/page-builder/utils/id.ts#L13).

Make config changes so `@craftjs/utils` can be resolved to this fork instead of the version listed in `@craftjs/core`'s package.json:
- Remove `src` from npmignore file
- Change main/module fields to point to `src/index.ts` rather than the built JS in `dist` (which will no longer exist when installed).

Note: merging this takes no effect in `react-app`. After this is merged we need to remove and re-add the `@craftjs/core` package so this latest commit is pulled in (can be verified in the `yarn.lock` file). There will also be webpack config updates to process `@craftjs/utils` (see https://github.com/kizen/react-app/blob/develop/apps/react-app/config-overrides.js#L10). Might also need a special resolution for `@craftjs/utils` in the root package.json.

https://kizen.atlassian.net/browse/KZN-8239