### PR TITLE
Feature/kzn 10702 prepare for react app vite local development

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@
 packages/docs
 packages/examples/landing
 site/
+examples/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
     'prettier/@typescript-eslint',
     'plugin:prettier/recommended',
     'react-app',
-    "plugin:import/typescript",
+    'plugin:import/typescript',
   ],
   rules: {
     'no-console': 1,

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 .cache
 *-cache
 out
-dist
 lib
 *-*.log
 .now

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prettier": "2.0.1",
     "pretty-quick": "2.0.1",
     "rimraf": "3.0.2",
+    "rollup": "^4.17.2",
     "rollup-plugin-babel": "4.3.3",
     "rollup-plugin-commonjs": "10.1.0",
     "rollup-plugin-node-resolve": "5.2.0",
@@ -119,8 +120,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "jest"
+      "pre-commit": "lint-staged"
     }
   },
   "resolutions": {

--- a/packages/core/dist/esm/index.js
+++ b/packages/core/dist/esm/index.js
@@ -1,0 +1,2073 @@
+import {
+  ERROR_USE_EDITOR_OUTSIDE_OF_EDITOR_CONTEXT as e,
+  useCollector as t,
+  wrapConnectorHooks as n,
+  ERROR_USE_NODE_OUTSIDE_OF_EDITOR_CONTEXT as r,
+  deprecationWarning as o,
+  useEffectOnce as a,
+  ERROR_TOP_LEVEL_ELEMENT_NO_ID as i,
+  ROOT_NODE as d,
+  ERROR_INVALID_NODEID as s,
+  ERROR_DELETE_TOP_LEVEL_NODE as u,
+  ERROR_NOPARENT as c,
+  DEPRECATED_ROOT_NODE as l,
+  ERROR_NOT_IN_RESOLVER as f,
+  ERROR_INVALID_NODE_ID as p,
+  ERROR_MOVE_TOP_LEVEL_NODE as v,
+  ERROR_MOVE_NONCANVAS_CHILD as h,
+  ERROR_CANNOT_DRAG as g,
+  ERROR_MOVE_TO_NONCANVAS_PARENT as y,
+  ERROR_MOVE_INCOMING_PARENT as m,
+  ERROR_MOVE_CANNOT_DROP as N,
+  ERROR_MOVE_TO_DESCENDANT as E,
+  ERROR_DUPLICATE_NODEID as O,
+  ERROR_MOVE_OUTGOING_PARENT as b,
+  getRandomId as C,
+  ERROR_DESERIALIZE_COMPONENT_NOT_IN_RESOLVER as T,
+  getDOMInfo as k,
+  EventHandlers as D,
+  DerivedEventHandlers as w,
+  isChromium as x,
+  isLinux as I,
+  RenderIndicator as S,
+  useMethods as j,
+  ERROR_RESOLVER_NOT_AN_OBJECT as q,
+  HISTORY_ACTIONS as P,
+} from '@craftjs/utils';
+export { ROOT_NODE } from '@craftjs/utils';
+import L, {
+  createContext as R,
+  useContext as A,
+  useMemo as _,
+  useEffect as F,
+  useState as z,
+  useRef as M,
+  Children as B,
+  Fragment as H,
+} from 'react';
+import W from 'tiny-invariant';
+import { isFunction as $, pickBy as J } from 'lodash';
+import V from 'lodash/cloneDeep';
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */ var X = function (
+  e,
+  t
+) {
+  return (X =
+    Object.setPrototypeOf ||
+    ({ __proto__: [] } instanceof Array &&
+      function (e, t) {
+        e.__proto__ = t;
+      }) ||
+    function (e, t) {
+      for (var n in t)
+        Object.prototype.hasOwnProperty.call(t, n) && (e[n] = t[n]);
+    })(e, t);
+};
+function Y(e, t) {
+  if ('function' != typeof t && null !== t)
+    throw new TypeError(
+      'Class extends value ' + String(t) + ' is not a constructor or null'
+    );
+  function n() {
+    this.constructor = e;
+  }
+  X(e, t),
+    (e.prototype =
+      null === t ? Object.create(t) : ((n.prototype = t.prototype), new n()));
+}
+var G = function () {
+  return (G =
+    Object.assign ||
+    function (e) {
+      for (var t, n = 1, r = arguments.length; n < r; n++)
+        for (var o in (t = arguments[n]))
+          Object.prototype.hasOwnProperty.call(t, o) && (e[o] = t[o]);
+      return e;
+    }).apply(this, arguments);
+};
+function K(e, t) {
+  var n = {};
+  for (var r in e)
+    Object.prototype.hasOwnProperty.call(e, r) &&
+      t.indexOf(r) < 0 &&
+      (n[r] = e[r]);
+  if (null != e && 'function' == typeof Object.getOwnPropertySymbols) {
+    var o = 0;
+    for (r = Object.getOwnPropertySymbols(e); o < r.length; o++)
+      t.indexOf(r[o]) < 0 &&
+        Object.prototype.propertyIsEnumerable.call(e, r[o]) &&
+        (n[r[o]] = e[r[o]]);
+  }
+  return n;
+}
+function U() {
+  for (var e = 0, t = 0, n = arguments.length; t < n; t++)
+    e += arguments[t].length;
+  var r = Array(e),
+    o = 0;
+  for (t = 0; t < n; t++)
+    for (var a = arguments[t], i = 0, d = a.length; i < d; i++, o++)
+      r[o] = a[i];
+  return r;
+}
+var Q = L.createContext(null),
+  Z = function (e) {
+    var t = e.related;
+    return L.createElement(
+      Q.Provider,
+      { value: { id: e.id, related: void 0 !== t && t } },
+      e.children
+    );
+  },
+  ee = R(null),
+  te = R(null),
+  ne = function () {
+    return A(te);
+  };
+function re(r) {
+  var o = ne(),
+    a = A(ee);
+  W(a, e);
+  var i = t(a, r),
+    d = _(
+      function () {
+        return o && o.createConnectorsUsage();
+      },
+      [o]
+    );
+  F(
+    function () {
+      return (
+        d.register(),
+        function () {
+          d.cleanup();
+        }
+      );
+    },
+    [d]
+  );
+  var s = _(
+    function () {
+      return d && n(d.connectors);
+    },
+    [d]
+  );
+  return G(G({}, i), { connectors: s, inContext: !!a, store: a });
+}
+function oe(e) {
+  var t = A(Q);
+  W(t, r);
+  var o = t.id,
+    a = t.related,
+    i = re(function (t) {
+      return o && t.nodes[o] && e && e(t.nodes[o]);
+    }),
+    d = i.actions,
+    s = i.connectors,
+    u = K(i, ['actions', 'query', 'connectors']),
+    c = _(
+      function () {
+        return n({
+          connect: function (e) {
+            return s.connect(e, o);
+          },
+          drag: function (e) {
+            return s.drag(e, o);
+          },
+        });
+      },
+      [s, o]
+    ),
+    l = _(
+      function () {
+        return {
+          setProp: function (e, t) {
+            t ? d.history.throttle(t).setProp(o, e) : d.setProp(o, e);
+          },
+          setCustom: function (e, t) {
+            t ? d.history.throttle(t).setCustom(o, e) : d.setCustom(o, e);
+          },
+          setHidden: function (e) {
+            return d.setHidden(o, e);
+          },
+        };
+      },
+      [d, o]
+    );
+  return G(G({}, u), {
+    id: o,
+    related: a,
+    inNodeContext: !!t,
+    actions: l,
+    connectors: c,
+  });
+}
+function ae(e) {
+  var t = oe(e),
+    n = t.id,
+    r = t.related,
+    a = t.actions,
+    i = t.inNodeContext,
+    d = t.connectors,
+    s = K(t, ['id', 'related', 'actions', 'inNodeContext', 'connectors']);
+  return G(G({}, s), {
+    actions: a,
+    id: n,
+    related: r,
+    setProp: function (e, t) {
+      return (
+        o('useNode().setProp()', { suggest: 'useNode().actions.setProp()' }),
+        a.setProp(e, t)
+      );
+    },
+    inNodeContext: i,
+    connectors: d,
+  });
+}
+var ie = function (e) {
+    var t = e.render,
+      n = ae().connectors;
+    return 'string' == typeof t.type
+      ? (0, n.connect)((0, n.drag)(L.cloneElement(t)))
+      : t;
+  },
+  de = function (e) {
+    var t = oe(function (e) {
+        return {
+          type: e.data.type,
+          props: e.data.props,
+          nodes: e.data.nodes,
+          hydrationTimestamp: e._hydrationTimestamp,
+        };
+      }),
+      n = t.type,
+      r = t.props,
+      o = t.nodes;
+    return _(
+      function () {
+        var t = r.children;
+        o &&
+          o.length > 0 &&
+          (t = L.createElement(
+            L.Fragment,
+            null,
+            o.map(function (e) {
+              return L.createElement(ue, { id: e, key: e });
+            })
+          ));
+        var a = L.createElement(n, G(G({}, r), e), t);
+        return 'string' == typeof n ? L.createElement(ie, { render: a }) : a;
+      },
+      [n, r, e, t.hydrationTimestamp, o]
+    );
+  },
+  se = function (e) {
+    var t = e.render,
+      n = K(e, ['render']),
+      r = oe(function (e) {
+        return { hidden: e.data.hidden };
+      }).hidden,
+      o = re(function (e) {
+        return { onRender: e.options.onRender };
+      }).onRender;
+    return r
+      ? null
+      : L.createElement(o, { render: t || L.createElement(de, G({}, n)) });
+  },
+  ue = function (e) {
+    var t = e.id,
+      n = e.render,
+      r = K(e, ['id', 'render']);
+    return L.createElement(
+      Z,
+      { id: t },
+      L.createElement(se, G({ render: n }, r))
+    );
+  },
+  ce = { is: 'div', canvas: !1, custom: {}, hidden: !1 },
+  le = { is: 'type', canvas: 'isCanvas' };
+function fe(e) {
+  var t = e.id,
+    n = e.children,
+    r = K(e, ['id', 'children']),
+    o = G(G({}, ce), r).is,
+    d = re(),
+    s = d.query,
+    u = d.actions,
+    c = oe(function (e) {
+      return { node: { id: e.id, data: e.data } };
+    }),
+    l = c.node,
+    f = c.inNodeContext,
+    p = z(null),
+    v = p[0],
+    h = p[1];
+  return (
+    a(function () {
+      W(!!t, i);
+      var e = l.id,
+        a = l.data;
+      if (f) {
+        var d,
+          c =
+            a.linkedNodes && a.linkedNodes[t] && s.node(a.linkedNodes[t]).get();
+        if (c && c.data.type === o) d = c.id;
+        else {
+          var p = L.createElement(fe, r, n),
+            v = s.parseReactElement(p).toNodeTree();
+          (d = v.rootNodeId), u.history.ignore().addLinkedNodeFromTree(v, e, t);
+        }
+        h(d);
+      }
+    }),
+    v ? L.createElement(ue, G({ id: v }, r)) : null
+  );
+}
+var pe = function () {
+  return o('<Canvas />', { suggest: '<Element canvas={true} />' });
+};
+function Canvas(e) {
+  var t = K(e, []);
+  return (
+    F(function () {
+      return pe();
+    }, []),
+    L.createElement(fe, G({}, t, { canvas: !0 }))
+  );
+}
+var ve,
+  he = function () {
+    var e = re(function (e) {
+      return { timestamp: e.nodes[d] && e.nodes[d]._hydrationTimestamp };
+    }).timestamp;
+    return e ? L.createElement(ue, { id: d, key: e }) : null;
+  },
+  ge = function (e) {
+    var t = e.children,
+      n = e.json,
+      r = e.data,
+      a = re(),
+      i = a.actions,
+      s = a.query;
+    n && o('<Frame json={...} />', { suggest: '<Frame data={...} />' });
+    var u = M({ initialChildren: t, initialData: r || n });
+    return (
+      F(
+        function () {
+          var e = u.current,
+            t = e.initialChildren,
+            n = e.initialData;
+          if (n) i.history.ignore().deserialize(n);
+          else if (t) {
+            var r = L.Children.only(t),
+              o = s.parseReactElement(r).toNodeTree(function (e, t) {
+                return t === r && (e.id = d), e;
+              });
+            i.history.ignore().addNodeTree(o);
+          }
+        },
+        [i, s]
+      ),
+      L.createElement(he, null)
+    );
+  };
+!(function (e) {
+  (e[(e.Any = 0)] = 'Any'), (e[(e.Id = 1)] = 'Id'), (e[(e.Obj = 2)] = 'Obj');
+})(ve || (ve = {}));
+var ye = function (e) {
+  return K(e, [
+    'addLinkedNodeFromTree',
+    'setDOM',
+    'setNodeEvent',
+    'replaceNodes',
+    'reset',
+  ]);
+};
+function me(e) {
+  var t = re(e),
+    n = t.connectors,
+    r = t.actions,
+    o = K(t.query, ['deserialize']),
+    a = t.store,
+    i = K(t, ['connectors', 'actions', 'query', 'store']),
+    d = ye(r),
+    s = _(
+      function () {
+        return G(G({}, d), {
+          history: G(G({}, d.history), {
+            ignore: function () {
+              for (var e, t = [], n = 0; n < arguments.length; n++)
+                t[n] = arguments[n];
+              return ye((e = d.history).ignore.apply(e, t));
+            },
+            throttle: function () {
+              for (var e, t = [], n = 0; n < arguments.length; n++)
+                t[n] = arguments[n];
+              return ye((e = d.history).throttle.apply(e, t));
+            },
+          }),
+        });
+      },
+      [d]
+    );
+  return G({ connectors: n, actions: s, query: o, store: a }, i);
+}
+function Ne(e) {
+  return function (t) {
+    return function (n) {
+      var r = e ? me(e) : me();
+      return L.createElement(t, G({}, r, n));
+    };
+  };
+}
+function Ee(e) {
+  return function (t) {
+    return function (n) {
+      var r = ae(e);
+      return L.createElement(t, G({}, r, n));
+    };
+  };
+}
+var Oe = function (e) {
+    return Object.fromEntries
+      ? Object.fromEntries(e)
+      : e.reduce(function (e, t) {
+          var n,
+            r = t[0],
+            o = t[1];
+          return G(G({}, e), (((n = {})[r] = o), n));
+        }, {});
+  },
+  be = function (e, t, n) {
+    var r = Array.isArray(t) ? t : [t],
+      o = G({ existOnly: !1, idOnly: !1 }, n || {}),
+      a = r
+        .filter(function (e) {
+          return !!e;
+        })
+        .map(function (t) {
+          return 'string' == typeof t
+            ? { node: e[t], exists: !!e[t] }
+            : 'object' != typeof t || o.idOnly
+            ? { node: null, exists: !1 }
+            : { node: t, exists: !!e[t.id] };
+        });
+    return (
+      o.existOnly &&
+        W(
+          0 ===
+            a.filter(function (e) {
+              return !e.exists;
+            }).length,
+          s
+        ),
+      a
+    );
+  },
+  Ce = function (e, t) {
+    var n = t.name || t.displayName,
+      r = (function () {
+        if (e[n]) return n;
+        for (var r = 0; r < Object.keys(e).length; r++) {
+          var o = Object.keys(e)[r];
+          if (e[o] === t) return o;
+        }
+        return 'string' == typeof t ? t : void 0;
+      })();
+    return W(r, f.replace('%node_type%', n)), r;
+  },
+  Te = function (e, t) {
+    return 'string' == typeof e ? e : { resolvedName: Ce(t, e) };
+  },
+  ke = function (e, t) {
+    var n = e.type,
+      r = e.isCanvas,
+      o = e.props;
+    return (
+      (o = Object.keys(o).reduce(function (e, n) {
+        var r = o[n];
+        return (
+          null == r ||
+            (e[n] =
+              'children' === n && 'string' != typeof r
+                ? B.map(r, function (e) {
+                    return 'string' == typeof e ? e : ke(e, t);
+                  })
+                : r.type
+                ? ke(r, t)
+                : r),
+          e
+        );
+      }, {})),
+      { type: Te(n, t), isCanvas: !!r, props: o }
+    );
+  },
+  De = function (e, t) {
+    var n = e.type,
+      r = e.props,
+      o = e.isCanvas,
+      a = K(e, ['type', 'props', 'isCanvas', 'name']),
+      i = ke({ type: n, isCanvas: o, props: r }, t);
+    return G(G({}, i), a);
+  };
+function we(e, t) {
+  W('string' == typeof t, p);
+  var n = e.nodes[t],
+    r = function (t) {
+      return we(e, t);
+    };
+  return {
+    isCanvas: function () {
+      return !!n.data.isCanvas;
+    },
+    isRoot: function () {
+      return n.id === d;
+    },
+    isLinkedNode: function () {
+      return n.data.parent && r(n.data.parent).linkedNodes().includes(n.id);
+    },
+    isTopLevelNode: function () {
+      return this.isRoot() || this.isLinkedNode();
+    },
+    isDeletable: function () {
+      return !this.isTopLevelNode();
+    },
+    isParentOfTopLevelNodes: function () {
+      return n.data.linkedNodes && Object.keys(n.data.linkedNodes).length > 0;
+    },
+    isParentOfTopLevelCanvas: function () {
+      return (
+        o('query.node(id).isParentOfTopLevelCanvas', {
+          suggest: 'query.node(id).isParentOfTopLevelNodes',
+        }),
+        this.isParentOfTopLevelNodes()
+      );
+    },
+    isSelected: function () {
+      return e.events.selected.has(t);
+    },
+    isHovered: function () {
+      return e.events.hovered.has(t);
+    },
+    isDragged: function () {
+      return e.events.dragged.has(t);
+    },
+    get: function () {
+      return n;
+    },
+    ancestors: function (t) {
+      return (
+        void 0 === t && (t = !1),
+        (function n(r, o, a) {
+          void 0 === o && (o = []), void 0 === a && (a = 0);
+          var i = e.nodes[r];
+          return i
+            ? (o.push(r),
+              i.data.parent
+                ? ((t || (!t && 0 === a)) && (o = n(i.data.parent, o, a + 1)),
+                  o)
+                : o)
+            : o;
+        })(n.data.parent)
+      );
+    },
+    descendants: function (n, o) {
+      return (
+        void 0 === n && (n = !1),
+        (function t(a, i, d) {
+          return (
+            void 0 === i && (i = []),
+            void 0 === d && (d = 0),
+            (n || (!n && 0 === d)) && e.nodes[a]
+              ? ('childNodes' !== o &&
+                  r(a)
+                    .linkedNodes()
+                    .forEach(function (e) {
+                      i.push(e), (i = t(e, i, d + 1));
+                    }),
+                'linkedNodes' !== o &&
+                  r(a)
+                    .childNodes()
+                    .forEach(function (e) {
+                      i.push(e), (i = t(e, i, d + 1));
+                    }),
+                i)
+              : i
+          );
+        })(t)
+      );
+    },
+    linkedNodes: function () {
+      return Object.values(n.data.linkedNodes || {});
+    },
+    childNodes: function () {
+      return n.data.nodes || [];
+    },
+    isDraggable: function (t) {
+      try {
+        var o = n;
+        return (
+          W(!this.isTopLevelNode(), v),
+          W(we(e, o.data.parent).isCanvas(), h),
+          W(o.rules.canDrag(o, r), g),
+          !0
+        );
+      } catch (e) {
+        return t && t(e), !1;
+      }
+    },
+    isDroppable: function (t, o) {
+      var a = be(e.nodes, t),
+        i = n;
+      try {
+        W(this.isCanvas(), y),
+          W(
+            i.rules.canMoveIn(
+              a.map(function (e) {
+                return e.node;
+              }),
+              i,
+              r
+            ),
+            m
+          );
+        var d = {};
+        return (
+          a.forEach(function (t) {
+            var n = t.node,
+              o = t.exists;
+            if ((W(n.rules.canDrop(i, n, r), N), o)) {
+              W(!r(n.id).isTopLevelNode(), v);
+              var a = r(n.id).descendants(!0);
+              W(!a.includes(i.id) && i.id !== n.id, E);
+              var s = n.data.parent && e.nodes[n.data.parent];
+              W(s.data.isCanvas, h),
+                W(s || (!s && !e.nodes[n.id]), O),
+                s.id !== i.id && (d[s.id] || (d[s.id] = []), d[s.id].push(n));
+            }
+          }),
+          Object.keys(d).forEach(function (t) {
+            var n = e.nodes[t];
+            W(n.rules.canMoveOut(d[t], n, r), b);
+          }),
+          !0
+        );
+      } catch (e) {
+        return o && o(e), !1;
+      }
+    },
+    toSerializedNode: function () {
+      return De(n.data, e.options.resolver);
+    },
+    toNodeTree: function (e) {
+      var n = U([t], this.descendants(!0, e)).reduce(function (e, t) {
+        return (e[t] = r(t).get()), e;
+      }, {});
+      return { rootNodeId: t, nodes: n };
+    },
+    decendants: function (e) {
+      return (
+        void 0 === e && (e = !1),
+        o('query.node(id).decendants', {
+          suggest: 'query.node(id).descendants',
+        }),
+        this.descendants(e)
+      );
+    },
+    isTopLevelCanvas: function () {
+      return !this.isRoot() && !n.data.parent;
+    },
+  };
+}
+function xe(e, t, n, r) {
+  for (
+    var o = { parent: e, index: 0, where: 'before' },
+      a = 0,
+      i = 0,
+      d = 0,
+      s = 0,
+      u = 0,
+      c = 0,
+      l = 0,
+      f = t.length;
+    l < f;
+    l++
+  ) {
+    var p = t[l];
+    if (
+      ((c = p.top + p.outerHeight),
+      (s = p.left + p.outerWidth / 2),
+      (u = p.top + p.outerHeight / 2),
+      !((i && p.left > i) || (d && u >= d) || (a && p.left + p.outerWidth < a)))
+    )
+      if (((o.index = l), p.inFlow)) {
+        if (r < u) {
+          o.where = 'before';
+          break;
+        }
+        o.where = 'after';
+      } else
+        r < c && (d = c),
+          n < s
+            ? ((i = s), (o.where = 'before'))
+            : ((a = s), (o.where = 'after'));
+  }
+  return o;
+}
+var Ie = function (e) {
+  return 'string' == typeof e ? e : e.name;
+};
+function Se(e, t) {
+  var n = e.data.type,
+    r = {
+      id: e.id || C(),
+      _hydrationTimestamp: Date.now(),
+      data: G(
+        {
+          type: n,
+          name: Ie(n),
+          displayName: Ie(n),
+          props: {},
+          custom: {},
+          parent: null,
+          isCanvas: !1,
+          hidden: !1,
+          nodes: [],
+          linkedNodes: {},
+        },
+        e.data
+      ),
+      related: {},
+      events: { selected: !1, dragged: !1, hovered: !1 },
+      rules: {
+        canDrag: function () {
+          return !0;
+        },
+        canDrop: function () {
+          return !0;
+        },
+        canMoveIn: function () {
+          return !0;
+        },
+        canMoveOut: function () {
+          return !0;
+        },
+      },
+      dom: null,
+    };
+  if (r.data.type === fe || r.data.type === Canvas) {
+    var o = G(G({}, ce), r.data.props);
+    (r.data.props = Object.keys(r.data.props).reduce(function (e, t) {
+      return (
+        Object.keys(ce).includes(t)
+          ? (r.data[le[t] || t] = o[t])
+          : (e[t] = r.data.props[t]),
+        e
+      );
+    }, {})),
+      (r.data.name = Ie((n = r.data.type))),
+      (r.data.displayName = Ie(n)),
+      r.data.type === Canvas && ((r.data.isCanvas = !0), pe());
+  }
+  t && t(r);
+  var a = n.craft;
+  if (
+    a &&
+    ((r.data.displayName = a.displayName || a.name || r.data.displayName),
+    (r.data.props = G(G({}, a.props || a.defaultProps || {}), r.data.props)),
+    (r.data.custom = G(G({}, a.custom || {}), r.data.custom)),
+    null != a.isCanvas && (r.data.isCanvas = a.isCanvas),
+    a.rules &&
+      Object.keys(a.rules).forEach(function (e) {
+        ['canDrag', 'canDrop', 'canMoveIn', 'canMoveOut'].includes(e) &&
+          (r.rules[e] = a.rules[e]);
+      }),
+    a.related)
+  ) {
+    var i = { id: r.id, related: !0 };
+    Object.keys(a.related).forEach(function (e) {
+      r.related[e] = function () {
+        return L.createElement(Z, i, L.createElement(a.related[e]));
+      };
+    });
+  }
+  return r;
+}
+var je = function (e, t, n) {
+    var r = e.props,
+      o = (function (e, t) {
+        return 'object' == typeof e && e.resolvedName
+          ? 'Canvas' === e.resolvedName
+            ? Canvas
+            : t[e.resolvedName]
+          : 'string' == typeof e
+          ? e
+          : null;
+      })(e.type, t);
+    if (o) {
+      r = Object.keys(r).reduce(function (e, n) {
+        var o = r[n];
+        return (
+          (e[n] =
+            null == o
+              ? null
+              : 'object' == typeof o && o.resolvedName
+              ? je(o, t)
+              : 'children' === n && Array.isArray(o)
+              ? o.map(function (e) {
+                  return 'string' == typeof e ? e : je(e, t);
+                })
+              : o),
+          e
+        );
+      }, {});
+      var a = G({}, L.createElement(o, G({}, r)));
+      return G(G({}, a), { name: Ce(t, a.type) });
+    }
+  },
+  qe = function (e, t) {
+    var n, r;
+    if (t.length < 1) return ((n = {})[e.id] = e), n;
+    var o = t.map(function (e) {
+        return e.rootNodeId;
+      }),
+      a = G(G({}, e), { data: G(G({}, e.data), { nodes: o }) }),
+      i = (((r = {})[e.id] = a), r);
+    return t.reduce(function (t, n) {
+      var r,
+        o = n.nodes[n.rootNodeId];
+      return G(
+        G(G({}, t), n.nodes),
+        (((r = {})[o.id] = G(G({}, o), {
+          data: G(G({}, o.data), { parent: e.id }),
+        })),
+        r)
+      );
+    }, i);
+  };
+function Pe(e) {
+  var t = e && e.options,
+    n = function () {
+      return Pe(e);
+    };
+  return {
+    getDropPlaceholder: function (t, r, o, a) {
+      void 0 === a &&
+        (a = function (t) {
+          return e.nodes[t.id].dom;
+        });
+      var i = e.nodes[r],
+        d = n().node(i.id).isCanvas() ? i : e.nodes[i.data.parent];
+      if (d) {
+        var s = d.data.nodes || [],
+          u = xe(
+            d,
+            s
+              ? s.reduce(function (t, n) {
+                  var r = a(e.nodes[n]);
+                  if (r) {
+                    var o = G({ id: n }, k(r));
+                    t.push(o);
+                  }
+                  return t;
+                }, [])
+              : [],
+            o.x,
+            o.y
+          ),
+          c = s.length && e.nodes[s[u.index]],
+          l = { placement: G(G({}, u), { currentNode: c }), error: null };
+        return (
+          be(e.nodes, t).forEach(function (e) {
+            var t = e.node;
+            e.exists &&
+              n()
+                .node(t.id)
+                .isDraggable(function (e) {
+                  return (l.error = e);
+                });
+          }),
+          n()
+            .node(d.id)
+            .isDroppable(t, function (e) {
+              return (l.error = e);
+            }),
+          l
+        );
+      }
+    },
+    getOptions: function () {
+      return t;
+    },
+    getNodes: function () {
+      return e.nodes;
+    },
+    node: function (t) {
+      return we(e, t);
+    },
+    getSerializedNodes: function () {
+      var t = this,
+        n = Object.keys(e.nodes).map(function (e) {
+          return [e, t.node(e).toSerializedNode()];
+        });
+      return Oe(n);
+    },
+    getEvent: function (t) {
+      return (function (e, t) {
+        var n = e.events[t];
+        return {
+          contains: function (e) {
+            return n.has(e);
+          },
+          isEmpty: function () {
+            return 0 === this.all().length;
+          },
+          first: function () {
+            return this.all()[0];
+          },
+          last: function () {
+            var e = this.all();
+            return e[e.length - 1];
+          },
+          all: function () {
+            return Array.from(n);
+          },
+          size: function () {
+            return this.all().length;
+          },
+          at: function (e) {
+            return this.all()[e];
+          },
+          raw: function () {
+            return n;
+          },
+        };
+      })(e, t);
+    },
+    serialize: function () {
+      return JSON.stringify(this.getSerializedNodes());
+    },
+    parseReactElement: function (t) {
+      return {
+        toNodeTree: function (r) {
+          var o = (function (e, t) {
+              var n = e;
+              return (
+                'string' == typeof n && (n = L.createElement(H, {}, n)),
+                Se({ data: { type: n.type, props: G({}, n.props) } }, function (
+                  e
+                ) {
+                  t && t(e, n);
+                })
+              );
+            })(t, function (t, n) {
+              var o = Ce(e.options.resolver, t.data.type);
+              (t.data.displayName = t.data.displayName || o),
+                (t.data.name = o),
+                r && r(t, n);
+            }),
+            a = [];
+          return (
+            t.props &&
+              t.props.children &&
+              (a = L.Children.toArray(t.props.children).reduce(function (e, t) {
+                return (
+                  L.isValidElement(t) &&
+                    e.push(n().parseReactElement(t).toNodeTree(r)),
+                  e
+                );
+              }, [])),
+            (function (e, t) {
+              return { rootNodeId: e.id, nodes: qe(e, t) };
+            })(o, a)
+          );
+        },
+      };
+    },
+    parseSerializedNode: function (t) {
+      return {
+        toNode: function (r) {
+          var a = (function (e, t) {
+            var n = e.type,
+              r = K(e, ['type', 'props']);
+            W(
+              (void 0 !== n && 'string' == typeof n) ||
+                (void 0 !== n && void 0 !== n.resolvedName),
+              T.replace('%displayName%', e.displayName).replace(
+                '%availableComponents%',
+                Object.keys(t).join(', ')
+              )
+            );
+            var o = je(e, t),
+              a = o.name;
+            return {
+              type: o.type,
+              name: a,
+              displayName: r.displayName || a,
+              props: o.props,
+              custom: r.custom || {},
+              isCanvas: !!r.isCanvas,
+              hidden: !!r.hidden,
+              parent: r.parent,
+              linkedNodes: r.linkedNodes || r._childCanvas || {},
+              nodes: r.nodes || [],
+            };
+          })(t, e.options.resolver);
+          W(a.type, f);
+          var i = 'string' == typeof r && r;
+          return (
+            i &&
+              o('query.parseSerializedNode(...).toNode(id)', {
+                suggest:
+                  'query.parseSerializedNode(...).toNode(node => node.id = id)',
+              }),
+            n()
+              .parseFreshNode(G(G({}, i ? { id: i } : {}), { data: a }))
+              .toNode(!i && r)
+          );
+        },
+      };
+    },
+    parseFreshNode: function (t) {
+      return {
+        toNode: function (n) {
+          return Se(t, function (t) {
+            t.data.parent === l && (t.data.parent = d);
+            var r = Ce(e.options.resolver, t.data.type);
+            W(null !== r, f),
+              (t.data.displayName = t.data.displayName || r),
+              (t.data.name = r),
+              n && n(t);
+          });
+        },
+      };
+    },
+    createNode: function (e, t) {
+      o('query.createNode(' + e + ')', {
+        suggest: 'query.parseReactElement(' + e + ').toNodeTree()',
+      });
+      var n = this.parseReactElement(e).toNodeTree(),
+        r = n.nodes[n.rootNodeId];
+      return t
+        ? (t.id && (r.id = t.id),
+          t.data && (r.data = G(G({}, r.data), t.data)),
+          r)
+        : r;
+    },
+    getState: function () {
+      return e;
+    },
+  };
+}
+var Le = (function (e) {
+    function t() {
+      return (null !== e && e.apply(this, arguments)) || this;
+    }
+    return (
+      Y(t, e),
+      (t.prototype.handlers = function () {
+        return {
+          connect: function (e, t) {},
+          select: function (e, t) {},
+          hover: function (e, t) {},
+          drag: function (e, t) {},
+          drop: function (e, t) {},
+          create: function (e, t, n) {},
+        };
+      }),
+      t
+    );
+  })(D),
+  Re = (function (e) {
+    function t() {
+      return (null !== e && e.apply(this, arguments)) || this;
+    }
+    return Y(t, e), t;
+  })(w),
+  Ae = (function () {
+    function e(e, t) {
+      (this.store = e),
+        (this.dragTarget = t),
+        (this.currentIndicator = null),
+        (this.currentDropTargetId = null),
+        (this.currentDropTargetCanvasAncestorId = null),
+        (this.currentTargetId = null),
+        (this.currentTargetChildDimensions = null),
+        (this.currentIndicator = null),
+        (this.dragError = null),
+        (this.draggedNodes = this.getDraggedNodes()),
+        this.validateDraggedNodes(),
+        (this.onScrollListener = this.onScroll.bind(this)),
+        window.addEventListener('scroll', this.onScrollListener, !0);
+    }
+    return (
+      (e.prototype.cleanup = function () {
+        window.removeEventListener('scroll', this.onScrollListener, !0);
+      }),
+      (e.prototype.onScroll = function (e) {
+        var t = e.target,
+          n = this.store.query.node(d).get();
+        t instanceof Element &&
+          n &&
+          n.dom &&
+          t.contains(n.dom) &&
+          (this.currentTargetChildDimensions = null);
+      }),
+      (e.prototype.getDraggedNodes = function () {
+        return be(
+          this.store.query.getNodes(),
+          'new' === this.dragTarget.type
+            ? this.dragTarget.tree.nodes[this.dragTarget.tree.rootNodeId]
+            : this.dragTarget.nodes
+        );
+      }),
+      (e.prototype.validateDraggedNodes = function () {
+        var e = this;
+        'new' !== this.dragTarget.type &&
+          this.draggedNodes.forEach(function (t) {
+            t.exists &&
+              e.store.query.node(t.node.id).isDraggable(function (t) {
+                e.dragError = t;
+              });
+          });
+      }),
+      (e.prototype.isNearBorders = function (t, n, r) {
+        return (
+          t.top + e.BORDER_OFFSET > r ||
+          t.bottom - e.BORDER_OFFSET < r ||
+          t.left + e.BORDER_OFFSET > n ||
+          t.right - e.BORDER_OFFSET < n
+        );
+      }),
+      (e.prototype.isDiff = function (e) {
+        return (
+          !this.currentIndicator ||
+          this.currentIndicator.placement.parent.id !== e.parent.id ||
+          this.currentIndicator.placement.index !== e.index ||
+          this.currentIndicator.placement.where !== e.where
+        );
+      }),
+      (e.prototype.getChildDimensions = function (e) {
+        var t = this,
+          n = this.currentTargetChildDimensions;
+        return this.currentTargetId === e.id && n
+          ? n
+          : e.data.nodes.reduce(function (e, n) {
+              var r = t.store.query.node(n).get().dom;
+              return r && e.push(G({ id: n }, k(r))), e;
+            }, []);
+      }),
+      (e.prototype.getCanvasAncestor = function (e) {
+        var t = this;
+        if (
+          e === this.currentDropTargetId &&
+          this.currentDropTargetCanvasAncestorId
+        ) {
+          var n = this.store.query
+            .node(this.currentDropTargetCanvasAncestorId)
+            .get();
+          if (n) return n;
+        }
+        var r = function (e) {
+          var n = t.store.query.node(e).get();
+          return n && n.data.isCanvas
+            ? n
+            : n.data.parent
+            ? r(n.data.parent)
+            : null;
+        };
+        return r(e);
+      }),
+      (e.prototype.computeIndicator = function (e, t, n) {
+        var r = this.getCanvasAncestor(e);
+        if (
+          r &&
+          ((this.currentDropTargetId = e),
+          (this.currentDropTargetCanvasAncestorId = r.id),
+          r.data.parent &&
+            this.isNearBorders(k(r.dom), t, n) &&
+            !this.store.query.node(r.id).isLinkedNode() &&
+            (r = this.store.query.node(r.data.parent).get()),
+          r)
+        ) {
+          (this.currentTargetChildDimensions = this.getChildDimensions(r)),
+            (this.currentTargetId = r.id);
+          var o = xe(r, this.currentTargetChildDimensions, t, n);
+          if (this.isDiff(o)) {
+            var a = this.dragError;
+            a ||
+              this.store.query.node(r.id).isDroppable(
+                this.draggedNodes.map(function (e) {
+                  return e.node;
+                }),
+                function (e) {
+                  a = e;
+                }
+              );
+            var i = r.data.nodes[o.index],
+              d = i && this.store.query.node(i).get();
+            return (
+              (this.currentIndicator = {
+                placement: G(G({}, o), { currentNode: d }),
+                error: a,
+              }),
+              this.currentIndicator
+            );
+          }
+        }
+      }),
+      (e.prototype.getIndicator = function () {
+        return this.currentIndicator;
+      }),
+      (e.BORDER_OFFSET = 10),
+      e
+    );
+  })(),
+  _e = function (e, t, n) {
+    if ((void 0 === n && (n = !1), 1 === t.length || n)) {
+      var r = t[0].getBoundingClientRect(),
+        o = r.width,
+        a = r.height,
+        i = t[0].cloneNode(!0);
+      return (
+        (i.style.position = 'fixed'),
+        (i.style.left = '-100%'),
+        (i.style.top = '-100%'),
+        (i.style.width = o + 'px'),
+        (i.style.height = a + 'px'),
+        (i.style.pointerEvents = 'none'),
+        document.body.appendChild(i),
+        e.dataTransfer.setDragImage(i, 0, 0),
+        i
+      );
+    }
+    var d = document.createElement('div');
+    return (
+      (d.style.position = 'fixed'),
+      (d.style.left = '-100%'),
+      (d.style.top = '-100%'),
+      (d.style.width = '100%'),
+      (d.style.height = '100%'),
+      (d.style.pointerEvents = 'none'),
+      t.forEach(function (e) {
+        var t = e.getBoundingClientRect(),
+          n = t.width,
+          r = t.height,
+          o = t.top,
+          a = t.left,
+          i = e.cloneNode(!0);
+        (i.style.position = 'absolute'),
+          (i.style.left = a + 'px'),
+          (i.style.top = o + 'px'),
+          (i.style.width = n + 'px'),
+          (i.style.height = r + 'px'),
+          d.appendChild(i);
+      }),
+      document.body.appendChild(d),
+      e.dataTransfer.setDragImage(d, e.clientX, e.clientY),
+      d
+    );
+  },
+  Fe = (function (e) {
+    function t() {
+      var t = (null !== e && e.apply(this, arguments)) || this;
+      return (t.positioner = null), (t.currentSelectedElementIds = []), t;
+    }
+    return (
+      Y(t, e),
+      (t.prototype.onDisable = function () {
+        this.options.store.actions.clearEvents();
+      }),
+      (t.prototype.handlers = function () {
+        var e = this,
+          n = this.options.store;
+        return {
+          connect: function (t, r) {
+            return (
+              n.actions.setDOM(r, t),
+              e.reflect(function (e) {
+                e.select(t, r), e.hover(t, r), e.drop(t, r);
+              })
+            );
+          },
+          select: function (t, r) {
+            var o = e.addCraftEventListener(t, 'mousedown', function (t) {
+                t.craft.stopPropagation();
+                var o = [];
+                if (r) {
+                  var a = n.query,
+                    i = a.getEvent('selected').all();
+                  (e.options.isMultiSelectEnabled(t) || i.includes(r)) &&
+                    (o = i.filter(function (e) {
+                      var t = a.node(e).descendants(!0),
+                        n = a.node(e).ancestors(!0);
+                      return !t.includes(r) && !n.includes(r);
+                    })),
+                    o.includes(r) || o.push(r);
+                }
+                n.actions.setNodeEvent('selected', o);
+              }),
+              a = e.addCraftEventListener(t, 'click', function (t) {
+                t.craft.stopPropagation();
+                var o = n.query.getEvent('selected').all(),
+                  a = e.options.isMultiSelectEnabled(t),
+                  i = e.currentSelectedElementIds.includes(r),
+                  d = U(o);
+                a && i
+                  ? (d.splice(d.indexOf(r), 1),
+                    n.actions.setNodeEvent('selected', d))
+                  : !a &&
+                    o.length > 1 &&
+                    n.actions.setNodeEvent('selected', (d = [r])),
+                  (e.currentSelectedElementIds = d);
+              });
+            return function () {
+              o(), a();
+            };
+          },
+          hover: function (t, r) {
+            var o = e.addCraftEventListener(t, 'mouseover', function (e) {
+              e.craft.stopPropagation(), n.actions.setNodeEvent('hovered', r);
+            });
+            return function () {
+              o();
+            };
+          },
+          drop: function (t, r) {
+            var o = e.addCraftEventListener(t, 'dragover', function (t) {
+                if (
+                  (t.craft.stopPropagation(), t.preventDefault(), e.positioner)
+                ) {
+                  var o = e.positioner.computeIndicator(
+                    r,
+                    t.clientX,
+                    t.clientY
+                  );
+                  o && n.actions.setIndicator(o);
+                }
+              }),
+              a = e.addCraftEventListener(t, 'dragenter', function (e) {
+                e.craft.stopPropagation(), e.preventDefault();
+              });
+            return function () {
+              a(), o();
+            };
+          },
+          drag: function (t, r) {
+            if (!n.query.node(r).isDraggable()) return function () {};
+            t.setAttribute('draggable', 'true');
+            var o = e.addCraftEventListener(t, 'dragstart', function (t) {
+                t.craft.stopPropagation();
+                var o = n.actions,
+                  a = n.query.getEvent('selected').all(),
+                  i = e.options.isMultiSelectEnabled(t);
+                e.currentSelectedElementIds.includes(r) ||
+                  ((a = i ? U(a, [r]) : [r]),
+                  n.actions.setNodeEvent('selected', a)),
+                  o.setNodeEvent('dragged', a),
+                  (e.dragTarget = { type: 'existing', nodes: a }),
+                  (e.positioner = new Ae(e.options.store, e.dragTarget));
+              }),
+              a = e.addCraftEventListener(t, 'dragend', function (t) {
+                t.craft.stopPropagation(),
+                  e.dropElement(function (e, t) {
+                    'new' !== e.type &&
+                      n.actions.move(
+                        e.nodes,
+                        t.placement.parent.id,
+                        t.placement.index +
+                          ('after' === t.placement.where ? 1 : 0)
+                      );
+                  });
+              });
+            return function () {
+              t.setAttribute('draggable', 'false'), o(), a();
+            };
+          },
+          create: function (r, o, a) {
+            r.setAttribute('draggable', 'true');
+            var i = e.addCraftEventListener(r, 'dragstart', function (r) {
+                var a;
+                if ((r.craft.stopPropagation(), 'function' == typeof o)) {
+                  var i = o();
+                  a = L.isValidElement(i)
+                    ? n.query.parseReactElement(i).toNodeTree()
+                    : i;
+                } else a = n.query.parseReactElement(o).toNodeTree();
+                (e.draggedElementShadow = _e(
+                  r,
+                  [r.currentTarget],
+                  t.forceSingleDragShadow
+                )),
+                  (e.dragTarget = { type: 'new', tree: a }),
+                  (e.positioner = new Ae(e.options.store, e.dragTarget));
+              }),
+              d = e.addCraftEventListener(r, 'dragend', function (t) {
+                t.craft.stopPropagation(),
+                  e.dropElement(function (e, t) {
+                    'existing' !== e.type &&
+                      (n.actions.addNodeTree(
+                        e.tree,
+                        t.placement.parent.id,
+                        t.placement.index +
+                          ('after' === t.placement.where ? 1 : 0)
+                      ),
+                      a && $(a.onCreate) && a.onCreate(e.tree));
+                  });
+              });
+            return function () {
+              r.removeAttribute('draggable'), i(), d();
+            };
+          },
+          attach: function (r, o, a) {
+            var i = a.onDragStart,
+              d = a.onDragEnd;
+            r.setAttribute('draggable', 'true');
+            var s = e.addCraftEventListener(r, 'dragstart', function (r) {
+                r.craft.stopPropagation();
+                var a = n.getState().options.resolver,
+                  d = n.query
+                    .parseReactElement(L.createElement(a[o]))
+                    .toNodeTree();
+                (e.draggedElementShadow = _e(
+                  r,
+                  [r.currentTarget],
+                  t.forceSingleDragShadow
+                )),
+                  (e.dragTarget = { type: 'new', tree: d }),
+                  (e.positioner = new Ae(e.options.store, e.dragTarget)),
+                  i();
+              }),
+              u = e.addCraftEventListener(r, 'dragend', function (t) {
+                t.craft.stopPropagation(),
+                  d(),
+                  e.dropElement(function () {
+                    return null;
+                  });
+              });
+            return function () {
+              r.setAttribute('draggable', 'false'), s(), u();
+            };
+          },
+        };
+      }),
+      (t.prototype.dropElement = function (e) {
+        var t = this.options.store;
+        if (this.positioner) {
+          var n = this.draggedElementShadow,
+            r = this.positioner.getIndicator();
+          this.dragTarget && r && !r.error && e(this.dragTarget, r),
+            n &&
+              (n.parentNode.removeChild(n), (this.draggedElementShadow = null)),
+            (this.dragTarget = null),
+            t.actions.setIndicator(null),
+            t.actions.setNodeEvent('dragged', null),
+            this.positioner.cleanup(),
+            (this.positioner = null);
+        }
+      }),
+      (t.forceSingleDragShadow = x() && I()),
+      t
+    );
+  })(Le);
+function ze(e, t, n, r) {
+  void 0 === r && (r = 2);
+  var o = 0,
+    a = 0,
+    i = 0,
+    d = 0,
+    s = e.where;
+  return (
+    n
+      ? n.inFlow
+        ? ((i = n.outerWidth),
+          (d = r),
+          (o = 'before' === s ? n.top : n.bottom),
+          (a = n.left))
+        : ((i = r),
+          (d = n.outerHeight),
+          (o = n.top),
+          (a = 'before' === s ? n.left : n.left + n.outerWidth))
+      : t &&
+        ((o = t.top + t.padding.top),
+        (a = t.left + t.padding.left),
+        (i =
+          t.outerWidth -
+          t.padding.right -
+          t.padding.left -
+          t.margin.left -
+          t.margin.right),
+        (d = r)),
+    { top: o + 'px', left: a + 'px', width: i + 'px', height: d + 'px' }
+  );
+}
+var Me = function () {
+    var e = re(function (e) {
+        return {
+          indicator: e.indicator,
+          indicatorOptions: e.options.indicator,
+          enabled: e.options.enabled,
+        };
+      }),
+      t = e.indicator,
+      n = e.indicatorOptions,
+      r = e.enabled,
+      o = ne();
+    return (
+      F(
+        function () {
+          o && (r ? o.enable() : o.disable());
+        },
+        [r, o]
+      ),
+      t
+        ? L.createElement(S, {
+            style: G(
+              G(
+                {},
+                ze(
+                  t.placement,
+                  k(t.placement.parent.dom),
+                  t.placement.currentNode && k(t.placement.currentNode.dom),
+                  n.thickness
+                )
+              ),
+              {
+                backgroundColor: t.error ? n.error : n.success,
+                transition: n.transition || '0.2s ease-in',
+              }
+            ),
+            parentDom: t.placement.parent.dom,
+          })
+        : null
+    );
+  },
+  Be = function (e) {
+    var t = e.children,
+      n = A(ee),
+      r = _(
+        function () {
+          return n.query.getOptions().handlers(n);
+        },
+        [n]
+      );
+    return r
+      ? L.createElement(te.Provider, { value: r }, L.createElement(Me, null), t)
+      : null;
+  },
+  He = {
+    nodes: {},
+    events: { dragged: new Set(), selected: new Set(), hovered: new Set() },
+    indicator: null,
+    handlers: null,
+    options: {
+      onNodesChange: function () {
+        return null;
+      },
+      onRender: function (e) {
+        return e.render;
+      },
+      onBeforeMoveEnd: function () {
+        return null;
+      },
+      resolver: {},
+      enabled: !0,
+      indicator: { error: 'red', success: 'rgb(98, 196, 98)' },
+      handlers: function (e) {
+        return new Fe({
+          store: e,
+          isMultiSelectEnabled: function (e) {
+            return !!e.metaKey;
+          },
+        });
+      },
+      normalizeNodes: function () {},
+    },
+  },
+  We = {
+    methods: function (e, t) {
+      return G(
+        G(
+          {},
+          (function (e, t) {
+            var n = function (t, n, o) {
+                var a = function (n, r) {
+                  var o = t.nodes[n];
+                  'string' != typeof o.data.type &&
+                    W(
+                      e.options.resolver[o.data.name],
+                      f.replace('%node_type%', '' + o.data.type.name)
+                    ),
+                    (e.nodes[n] = G(G({}, o), {
+                      data: G(G({}, o.data), { parent: r }),
+                    })),
+                    o.data.nodes.length > 0 &&
+                      (delete e.nodes[n].data.props.children,
+                      o.data.nodes.forEach(function (e) {
+                        return a(e, o.id);
+                      })),
+                    Object.values(o.data.linkedNodes).forEach(function (e) {
+                      return a(e, o.id);
+                    });
+                };
+                if ((a(t.rootNodeId, n), n)) {
+                  var i = r(n);
+                  if ('child' !== o.type)
+                    i.data.linkedNodes[o.id] = t.rootNodeId;
+                  else {
+                    var s = o.index;
+                    null != s
+                      ? i.data.nodes.splice(s, 0, t.rootNodeId)
+                      : i.data.nodes.push(t.rootNodeId);
+                  }
+                } else
+                  W(
+                    t.rootNodeId === d,
+                    'Cannot add non-root Node without a parent'
+                  );
+              },
+              r = function (t) {
+                W(t, c);
+                var n = e.nodes[t];
+                return W(n, s), n;
+              },
+              a = function (t) {
+                var n = e.nodes[t],
+                  r = e.nodes[n.data.parent];
+                if (
+                  (n.data.nodes &&
+                    U(n.data.nodes).forEach(function (e) {
+                      return a(e);
+                    }),
+                  n.data.linkedNodes &&
+                    Object.values(n.data.linkedNodes).map(function (e) {
+                      return a(e);
+                    }),
+                  r.data.nodes.includes(t))
+                ) {
+                  var o = r.data.nodes;
+                  o.splice(o.indexOf(t), 1);
+                } else {
+                  var i = Object.keys(r.data.linkedNodes).find(function (e) {
+                    return r.data.linkedNodes[e] === e;
+                  });
+                  i && delete r.data.linkedNodes[i];
+                }
+                !(function (e, t) {
+                  Object.keys(e.events).forEach(function (n) {
+                    var r = e.events[n];
+                    r &&
+                      r.has &&
+                      r.has(t) &&
+                      (e.events[n] = new Set(
+                        Array.from(r).filter(function (e) {
+                          return t !== e;
+                        })
+                      ));
+                  });
+                })(e, t),
+                  delete e.nodes[t];
+              };
+            return {
+              addLinkedNodeFromTree: function (e, t, o) {
+                var i = r(t).data.linkedNodes[o];
+                i && a(i), n(e, t, { type: 'linked', id: o });
+              },
+              add: function (e, t, r) {
+                var a = [e];
+                Array.isArray(e) &&
+                  (o('actions.add(node: Node[])', {
+                    suggest: 'actions.add(node: Node)',
+                  }),
+                  (a = e)),
+                  a.forEach(function (e) {
+                    var o;
+                    n(
+                      { nodes: ((o = {}), (o[e.id] = e), o), rootNodeId: e.id },
+                      t,
+                      { type: 'child', index: r }
+                    );
+                  });
+              },
+              addNodeTree: function (e, t, r) {
+                n(e, t, { type: 'child', index: r });
+              },
+              delete: function (n) {
+                be(e.nodes, n, { existOnly: !0, idOnly: !0 }).forEach(function (
+                  e
+                ) {
+                  var n = e.node;
+                  W(!t.node(n.id).isTopLevelNode(), u), a(n.id);
+                });
+              },
+              deserialize: function (e) {
+                var n = 'string' == typeof e ? JSON.parse(e) : e,
+                  r = Object.keys(n).map(function (e) {
+                    var r = e;
+                    return (
+                      e === l && (r = d),
+                      [
+                        r,
+                        t.parseSerializedNode(n[e]).toNode(function (e) {
+                          return (e.id = r);
+                        }),
+                      ]
+                    );
+                  });
+                this.replaceNodes(Oe(r));
+              },
+              move: function (n, r, o) {
+                var a = be(e.nodes, n, { existOnly: !0 }),
+                  i = e.nodes[r],
+                  d = new Set();
+                a.forEach(function (n, a) {
+                  var s = n.node,
+                    u = s.id,
+                    c = s.data.parent;
+                  t.node(r).isDroppable([u], function (e) {
+                    throw new Error(e);
+                  }),
+                    e.options.onBeforeMoveEnd(s, i, e.nodes[c]);
+                  var l = e.nodes[c].data.nodes;
+                  d.add(l);
+                  var f = l.indexOf(u);
+                  (l[f] = '$$'),
+                    i.data.nodes.splice(o + a, 0, u),
+                    (e.nodes[u].data.parent = r);
+                }),
+                  d.forEach(function (e) {
+                    var t = e.length;
+                    U(e)
+                      .reverse()
+                      .forEach(function (n, r) {
+                        '$$' === n && e.splice(t - 1 - r, 1);
+                      });
+                  });
+              },
+              replaceNodes: function (t) {
+                this.clearEvents(), (e.nodes = t);
+              },
+              clearEvents: function () {
+                this.setNodeEvent('selected', null),
+                  this.setNodeEvent('hovered', null),
+                  this.setNodeEvent('dragged', null),
+                  this.setIndicator(null);
+              },
+              reset: function () {
+                this.clearEvents(), this.replaceNodes({});
+              },
+              setOptions: function (t) {
+                t(e.options);
+              },
+              setNodeEvent: function (t, n) {
+                if (
+                  (e.events[t].forEach(function (n) {
+                    e.nodes[n] && (e.nodes[n].events[t] = !1);
+                  }),
+                  (e.events[t] = new Set()),
+                  n)
+                ) {
+                  var r = be(e.nodes, n, { idOnly: !0, existOnly: !0 }),
+                    o = new Set(
+                      r.map(function (e) {
+                        return e.node.id;
+                      })
+                    );
+                  o.forEach(function (n) {
+                    e.nodes[n].events[t] = !0;
+                  }),
+                    (e.events[t] = o);
+                }
+              },
+              setCustom: function (t, n) {
+                be(e.nodes, t, { idOnly: !0, existOnly: !0 }).forEach(function (
+                  t
+                ) {
+                  return n(e.nodes[t.node.id].data.custom);
+                });
+              },
+              setDOM: function (t, n) {
+                e.nodes[t] && (e.nodes[t].dom = n);
+              },
+              setIndicator: function (t) {
+                (t &&
+                  (!t.placement.parent.dom ||
+                    (t.placement.currentNode &&
+                      !t.placement.currentNode.dom))) ||
+                  (e.indicator = t);
+              },
+              setHidden: function (t, n) {
+                e.nodes[t].data.hidden = n;
+              },
+              setProp: function (t, n) {
+                be(e.nodes, t, { idOnly: !0, existOnly: !0 }).forEach(function (
+                  t
+                ) {
+                  return n(e.nodes[t.node.id].data.props);
+                });
+              },
+              selectNode: function (t) {
+                if (t) {
+                  var n = be(e.nodes, t, { idOnly: !0, existOnly: !0 });
+                  this.setNodeEvent(
+                    'selected',
+                    n.map(function (e) {
+                      return e.node.id;
+                    })
+                  );
+                } else this.setNodeEvent('selected', null);
+                this.setNodeEvent('hovered', null);
+              },
+            };
+          })(e, t)
+        ),
+        {
+          setState: function (t) {
+            var n = K(this, ['history']);
+            t(e, n);
+          },
+        }
+      );
+    },
+    ignoreHistoryForActions: [
+      'setDOM',
+      'setNodeEvent',
+      'selectNode',
+      'clearEvents',
+      'setOptions',
+      'setIndicator',
+    ],
+    normalizeHistory: function (e) {
+      Object.keys(e.events).forEach(function (t) {
+        Array.from(e.events[t] || []).forEach(function (n) {
+          e.nodes[n] || e.events[t].delete(n);
+        });
+      }),
+        Object.keys(e.nodes).forEach(function (t) {
+          var n = e.nodes[t];
+          Object.keys(n.events).forEach(function (t) {
+            n.events[t] &&
+              e.events[t] &&
+              !e.events[t].has(n.id) &&
+              (n.events[t] = !1);
+          });
+        });
+    },
+  },
+  $e = function (e, t) {
+    return j(We, G(G({}, He), { options: G(G({}, He.options), e) }), Pe, t);
+  },
+  Je = function (e) {
+    var t = e.children,
+      n = e.onRender,
+      r = e.onNodesChange,
+      o = e.onBeforeMoveEnd,
+      a = e.resolver,
+      i = e.enabled,
+      d = e.indicator;
+    void 0 !== a && W('object' == typeof a && !Array.isArray(a), q);
+    var s = _(
+        function () {
+          return J(
+            {
+              onRender: n,
+              onNodesChange: r,
+              onBeforeMoveEnd: o,
+              resolver: a,
+              enabled: i,
+              indicator: d,
+            },
+            function (e) {
+              return void 0 !== e;
+            }
+          );
+        },
+        [i, d, o, r, n, a]
+      ),
+      u = $e(s, function (e, t, n, r, o) {
+        if (n)
+          for (
+            var a = n.patches, i = K(n, ['patches']), d = 0;
+            d < a.length;
+            d++
+          ) {
+            var s = a[d].path,
+              u = s.length > 2 && 'nodes' === s[0] && 'data' === s[2];
+            if (
+              ([P.IGNORE, P.THROTTLE].includes(i.type) &&
+                i.params &&
+                (i.type = i.params[0]),
+              ['setState', 'deserialize'].includes(i.type) || u)
+            ) {
+              o(function (n) {
+                e.options.normalizeNodes &&
+                  e.options.normalizeNodes(n, t, i, r);
+              });
+              break;
+            }
+          }
+      });
+    return (
+      F(
+        function () {
+          u &&
+            s &&
+            u.actions.setOptions(function (e) {
+              Object.assign(e, s);
+            });
+        },
+        [u, s]
+      ),
+      F(
+        function () {
+          u.subscribe(
+            function (e) {
+              return { json: u.query.serialize() };
+            },
+            function () {
+              u.query.getOptions().onNodesChange(u.query);
+            }
+          );
+        },
+        [u]
+      ),
+      u
+        ? L.createElement(
+            ee.Provider,
+            { value: u },
+            L.createElement(Be, null, t)
+          )
+        : null
+    );
+  },
+  Ve = function (e) {
+    var t = e.events,
+      n = e.data,
+      r = n.nodes,
+      o = n.linkedNodes,
+      a = K(e, ['events', 'data']),
+      i = Se(V(e));
+    return {
+      node: (e = G(G(G({}, i), a), {
+        events: G(G({}, i.events), t),
+        dom: e.dom || i.dom,
+      })),
+      childNodes: r,
+      linkedNodes: o,
+    };
+  },
+  Xe = function (e, t) {
+    var n = t.nodes,
+      r = K(t, ['nodes']),
+      o = e.nodes,
+      a = K(e, ['nodes']);
+    expect(a).toEqual(r);
+    var i = Object.keys(n).reduce(function (e, t) {
+        var r = K(n[t], ['_hydrationTimestamp', 'rules']);
+        return (e[t] = r), e;
+      }, {}),
+      d = Object.keys(o).reduce(function (e, t) {
+        var n = K(o[t], ['_hydrationTimestamp', 'rules']);
+        return (e[t] = n), e;
+      }, {});
+    expect(d).toEqual(i);
+  },
+  Ye = function (e) {
+    var t = {},
+      n = function (e) {
+        var r = Ve(e),
+          o = r.node,
+          a = r.childNodes,
+          i = r.linkedNodes;
+        (t[o.id] = o),
+          a &&
+            a.forEach(function (e, r) {
+              var a = Ve(e),
+                i = a.node,
+                d = a.childNodes,
+                s = a.linkedNodes;
+              (i.data.parent = o.id),
+                (t[i.id] = i),
+                (o.data.nodes[r] = i.id),
+                n(
+                  G(G({}, i), {
+                    data: G(G({}, i.data), {
+                      nodes: d || [],
+                      linkedNodes: s || {},
+                    }),
+                  })
+                );
+            }),
+          i &&
+            Object.keys(i).forEach(function (e) {
+              var r = Ve(i[e]),
+                a = r.node,
+                d = r.childNodes,
+                s = r.linkedNodes;
+              (o.data.linkedNodes[e] = a.id),
+                (a.data.parent = o.id),
+                (t[a.id] = a),
+                n(
+                  G(G({}, a), {
+                    data: G(G({}, a.data), {
+                      nodes: d || [],
+                      linkedNodes: s || {},
+                    }),
+                  })
+                );
+            });
+      };
+    return n(e), t;
+  },
+  Ge = function (e) {
+    void 0 === e && (e = {});
+    var t = e.nodes,
+      n = e.events;
+    return G(G(G({}, He), e), {
+      nodes: t ? Ye(t) : {},
+      events: G(G({}, He.events), n || {}),
+    });
+  };
+export {
+  We as ActionMethodsWithConfig,
+  Canvas,
+  Le as CoreEventHandlers,
+  Fe as DefaultEventHandlers,
+  Re as DerivedCoreEventHandlers,
+  Je as Editor,
+  fe as Element,
+  Be as Events,
+  ge as Frame,
+  ue as NodeElement,
+  we as NodeHelpers,
+  Z as NodeProvider,
+  ve as NodeSelectorType,
+  Pe as QueryMethods,
+  Ne as connectEditor,
+  Ee as connectNode,
+  Ye as createTestNodes,
+  Ge as createTestState,
+  ce as defaultElementProps,
+  pe as deprecateCanvasComponent,
+  He as editorInitialState,
+  le as elementPropToNodeData,
+  Xe as expectEditorState,
+  De as serializeNode,
+  me as useEditor,
+  $e as useEditorStore,
+  ne as useEventHandler,
+  ae as useNode,
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@craftjs/core",
   "version": "0.2.0-beta.8",
   "description": "A React Framework for building extensible drag and drop page editors",
+  "type": "module",
   "keywords": [
     "react",
     "drag-and-drop",
@@ -18,8 +19,8 @@
   "author": "Prev Wong <prevwong@gmail.com>",
   "homepage": "https://github.com/prevwong/craft.js/",
   "license": "MIT",
-  "main": "./src/index.tsx",
-  "module": "./src/index.tsx",
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
   "types": "./lib/index.d.ts",
   "repository": {
     "type": "git",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@types/react": "17.0.2",
+    "cross-env": "^7.0.3",
     "react": "17.0.2"
   },
   "peerDependencies": {

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,4 +1,4 @@
-import config from '../../rollup.config';
+import config from '../../rollup.config.js';
 
 export default {
   ...config,

--- a/packages/core/src/nodes/Element.tsx
+++ b/packages/core/src/nodes/Element.tsx
@@ -81,5 +81,7 @@ export function Element<T extends React.ElementType>({
     }
   });
 
-  return linkedNodeId ? <NodeElement id={linkedNodeId} {...elementProps} /> : null;
+  return linkedNodeId ? (
+    <NodeElement id={linkedNodeId} {...elementProps} />
+  ) : null;
 }

--- a/packages/core/src/nodes/tests/Element.test.tsx
+++ b/packages/core/src/nodes/tests/Element.test.tsx
@@ -88,6 +88,7 @@ describe('<Element />', () => {
     it('should render a new linked Node', () => {
       expect(NodeElementTest).toHaveBeenCalledWith({
         id: newLinkedNode.id,
+        color: '#fff',
       });
     });
   });
@@ -113,6 +114,7 @@ describe('<Element />', () => {
     it('should render existing Node', () => {
       expect(NodeElementTest).toHaveBeenCalledWith({
         id: existingLinkedNode.id,
+        color: '#000',
       });
     });
   });

--- a/packages/core/src/render/RenderNode.tsx
+++ b/packages/core/src/render/RenderNode.tsx
@@ -24,5 +24,7 @@ export const RenderNodeToElement: React.FC<React.PropsWithChildren<
     return null;
   }
 
-  return React.createElement(onRender, { render: render || <DefaultRender {...rest} /> });
+  return React.createElement(onRender, {
+    render: render || <DefaultRender {...rest} />,
+  });
 };

--- a/packages/utils/.gitignore
+++ b/packages/utils/.gitignore
@@ -6,4 +6,3 @@ node_modules
 .rts2_cache_esm
 .rts2_cache_umd
 .rts2_cache_system
-dist

--- a/packages/utils/dist/esm/index.js
+++ b/packages/utils/dist/esm/index.js
@@ -1,0 +1,986 @@
+import t, {
+  applyPatches as e,
+  enableMapSet as n,
+  enablePatches as r,
+  produceWithPatches as i,
+} from 'immer';
+import o from 'lodash/isEqualWith';
+import a, {
+  useMemo as s,
+  useRef as c,
+  useCallback as u,
+  useEffect as l,
+  useState as p,
+  cloneElement as f,
+  isValidElement as d,
+} from 'react';
+import h from 'shallowequal';
+import { customAlphabet as y } from 'nanoid';
+import g from 'tiny-invariant';
+import m from 'react-dom';
+var v = 'ROOT',
+  b = 'canvas-ROOT',
+  E = 'Parent id cannot be ommited',
+  w = 'Attempting to add a node with duplicated id',
+  O = 'Node does not exist, it may have been removed',
+  R =
+    'A <Element /> that is used inside a User Component must specify an `id` prop, eg: <Element id="text_element">...</Element> ',
+  T =
+    'Placeholder required placement info (parent, index, or where) is missing',
+  C = 'Node cannot be dropped into target parent',
+  I = 'Target parent rejects incoming node',
+  H = 'Current parent rejects outgoing node',
+  D = 'Cannot move node that is not a direct child of a Canvas node',
+  P = 'Cannot move node into a non-Canvas parent',
+  x = 'A top-level Node cannot be moved',
+  N = 'Root Node cannot be moved',
+  A = 'Cannot move node into a descendant',
+  k =
+    'The component type specified for this node (%node_type%) does not exist in the resolver',
+  L =
+    "The component specified in the <Canvas> `is` prop has additional Canvas specified in it's render template.",
+  M =
+    'The node has specified a canDrag() rule that prevents it from being dragged',
+  S = 'Invalid parameter Node Id specified',
+  _ = 'Attempting to delete a top-level Node',
+  j =
+    'Resolver in <Editor /> has to be an object. For (de)serialization Craft.js needs a list of all the User Components. \n    \nMore info: https://craft.js.org/r/docs/api/editor#props',
+  U =
+    'An Error occurred while deserializing components: Cannot find component <%displayName% /> in resolver map. Please check your resolver in <Editor />\n\nAvailable components in resolver: %availableComponents%\n\nMore info: https://craft.js.org/r/docs/api/editor#props',
+  q =
+    'You can only use useEditor in the context of <Editor />. \n\nPlease only use useEditor in components that are children of the <Editor /> component.',
+  G =
+    'You can only use useNode in the context of <Editor />. \n\nPlease only use useNode in components that are children of the <Editor /> component.',
+  Y = function (t, e) {
+    return (Y =
+      Object.setPrototypeOf ||
+      ({ __proto__: [] } instanceof Array &&
+        function (t, e) {
+          t.__proto__ = e;
+        }) ||
+      function (t, e) {
+        for (var n in e)
+          Object.prototype.hasOwnProperty.call(e, n) && (t[n] = e[n]);
+      })(t, e);
+  },
+  B = function () {
+    return (B =
+      Object.assign ||
+      function (t) {
+        for (var e, n = 1, r = arguments.length; n < r; n++)
+          for (var i in (e = arguments[n]))
+            Object.prototype.hasOwnProperty.call(e, i) && (t[i] = e[i]);
+        return t;
+      }).apply(this, arguments);
+  };
+function W() {
+  for (var t = 0, e = 0, n = arguments.length; e < n; e++)
+    t += arguments[e].length;
+  var r = Array(t),
+    i = 0;
+  for (e = 0; e < n; e++)
+    for (var o = arguments[e], a = 0, s = o.length; a < s; a++, i++)
+      r[i] = o[a];
+  return r;
+}
+var z = {
+    UNDO: 'HISTORY_UNDO',
+    REDO: 'HISTORY_REDO',
+    THROTTLE: 'HISTORY_THROTTLE',
+    IGNORE: 'HISTORY_IGNORE',
+    MERGE: 'HISTORY_MERGE',
+    CLEAR: 'HISTORY_CLEAR',
+  },
+  F = (function () {
+    function t() {
+      (this.timeline = []), (this.pointer = -1);
+    }
+    return (
+      (t.prototype.add = function (t, e) {
+        (0 === t.length && 0 === e.length) ||
+          ((this.pointer = this.pointer + 1),
+          (this.timeline.length = this.pointer),
+          (this.timeline[this.pointer] = {
+            patches: t,
+            inversePatches: e,
+            timestamp: Date.now(),
+          }));
+      }),
+      (t.prototype.throttleAdd = function (t, e, n) {
+        if ((void 0 === n && (n = 500), 0 !== t.length || 0 !== e.length)) {
+          if (this.timeline.length && this.pointer >= 0) {
+            var r = this.timeline[this.pointer],
+              i = r.patches,
+              o = r.inversePatches,
+              a = r.timestamp;
+            if (new Date().getTime() - a < n)
+              return void (this.timeline[this.pointer] = {
+                timestamp: a,
+                patches: W(i, t),
+                inversePatches: W(e, o),
+              });
+          }
+          this.add(t, e);
+        }
+      }),
+      (t.prototype.merge = function (t, e) {
+        if (0 !== t.length || 0 !== e.length)
+          if (this.timeline.length && this.pointer >= 0) {
+            var n = this.timeline[this.pointer],
+              r = n.inversePatches;
+            this.timeline[this.pointer] = {
+              timestamp: n.timestamp,
+              patches: W(n.patches, t),
+              inversePatches: W(e, r),
+            };
+          } else this.add(t, e);
+      }),
+      (t.prototype.clear = function () {
+        (this.timeline = []), (this.pointer = -1);
+      }),
+      (t.prototype.canUndo = function () {
+        return this.pointer >= 0;
+      }),
+      (t.prototype.canRedo = function () {
+        return this.pointer < this.timeline.length - 1;
+      }),
+      (t.prototype.undo = function (t) {
+        if (this.canUndo()) {
+          var n = this.timeline[this.pointer].inversePatches;
+          return (this.pointer = this.pointer - 1), e(t, n);
+        }
+      }),
+      (t.prototype.redo = function (t) {
+        if (this.canRedo())
+          return (
+            (this.pointer = this.pointer + 1),
+            e(t, this.timeline[this.pointer].patches)
+          );
+      }),
+      t
+    );
+  })();
+function J(e, n, r, o) {
+  var a,
+    p = s(function () {
+      return new F();
+    }, []),
+    f = c([]),
+    d = c();
+  'function' == typeof e
+    ? (a = e)
+    : ((a = e.methods),
+      (f.current = e.ignoreHistoryForActions),
+      (d.current = e.normalizeHistory));
+  var h = c(o);
+  h.current = o;
+  var y = c(n),
+    g = s(
+      function () {
+        var e = d.current,
+          n = f.current,
+          o = h.current;
+        return function (s, c) {
+          var u,
+            l =
+              r &&
+              K(
+                r,
+                function () {
+                  return s;
+                },
+                p
+              ),
+            f = i(s, function (t) {
+              var e, n;
+              switch (c.type) {
+                case z.UNDO:
+                  return p.undo(t);
+                case z.REDO:
+                  return p.redo(t);
+                case z.CLEAR:
+                  return p.clear(), B({}, t);
+                case z.IGNORE:
+                case z.MERGE:
+                case z.THROTTLE:
+                  var r = c.payload,
+                    i = r[0],
+                    o = r.slice(1);
+                  (e = a(t, l))[i].apply(e, o);
+                  break;
+                default:
+                  (n = a(t, l))[c.type].apply(n, c.payload);
+              }
+            }),
+            d = f[0],
+            h = f[1],
+            y = f[2];
+          return (
+            (u = d),
+            o &&
+              o(
+                d,
+                s,
+                { type: c.type, params: c.payload, patches: h },
+                l,
+                function (t) {
+                  var e = i(d, t);
+                  (u = e[0]), (h = W(h, e[1])), (y = W(e[2], y));
+                }
+              ),
+            [z.UNDO, z.REDO].includes(c.type) && e && (u = t(u, e)),
+            W(n, [z.UNDO, z.REDO, z.IGNORE, z.CLEAR]).includes(c.type) ||
+              (c.type === z.THROTTLE
+                ? p.throttleAdd(h, y, c.config && c.config.rate)
+                : c.type === z.MERGE
+                ? p.merge(h, y)
+                : p.add(h, y)),
+            u
+          );
+        };
+      },
+      [p, a, r]
+    ),
+    m = u(function () {
+      return y.current;
+    }, []),
+    v = s(
+      function () {
+        return new Q(m);
+      },
+      [m]
+    ),
+    b = u(
+      function (t) {
+        var e = g(y.current, t);
+        (y.current = e), v.notify();
+      },
+      [g, v]
+    );
+  l(
+    function () {
+      v.notify();
+    },
+    [v]
+  );
+  var E = s(
+      function () {
+        return r
+          ? K(
+              r,
+              function () {
+                return y.current;
+              },
+              p
+            )
+          : [];
+      },
+      [p, r]
+    ),
+    w = s(
+      function () {
+        var t = Object.keys(a(null, null)),
+          e = f.current;
+        return B(
+          B(
+            {},
+            t.reduce(function (t, e) {
+              return (
+                (t[e] = function () {
+                  for (var t = [], n = 0; n < arguments.length; n++)
+                    t[n] = arguments[n];
+                  return b({ type: e, payload: t });
+                }),
+                t
+              );
+            }, {})
+          ),
+          {
+            history: {
+              undo: function () {
+                return b({ type: z.UNDO });
+              },
+              redo: function () {
+                return b({ type: z.REDO });
+              },
+              clear: function () {
+                return b({ type: z.CLEAR });
+              },
+              throttle: function (n) {
+                return B(
+                  {},
+                  t
+                    .filter(function (t) {
+                      return !e.includes(t);
+                    })
+                    .reduce(function (t, e) {
+                      return (
+                        (t[e] = function () {
+                          for (var t = [], r = 0; r < arguments.length; r++)
+                            t[r] = arguments[r];
+                          return b({
+                            type: z.THROTTLE,
+                            payload: W([e], t),
+                            config: { rate: n },
+                          });
+                        }),
+                        t
+                      );
+                    }, {})
+                );
+              },
+              ignore: function () {
+                return B(
+                  {},
+                  t
+                    .filter(function (t) {
+                      return !e.includes(t);
+                    })
+                    .reduce(function (t, e) {
+                      return (
+                        (t[e] = function () {
+                          for (var t = [], n = 0; n < arguments.length; n++)
+                            t[n] = arguments[n];
+                          return b({ type: z.IGNORE, payload: W([e], t) });
+                        }),
+                        t
+                      );
+                    }, {})
+                );
+              },
+              merge: function () {
+                return B(
+                  {},
+                  t
+                    .filter(function (t) {
+                      return !e.includes(t);
+                    })
+                    .reduce(function (t, e) {
+                      return (
+                        (t[e] = function () {
+                          for (var t = [], n = 0; n < arguments.length; n++)
+                            t[n] = arguments[n];
+                          return b({ type: z.MERGE, payload: W([e], t) });
+                        }),
+                        t
+                      );
+                    }, {})
+                );
+              },
+            },
+          }
+        );
+      },
+      [b, a]
+    );
+  return s(
+    function () {
+      return {
+        getState: m,
+        subscribe: function (t, e, n) {
+          return v.subscribe(t, e, n);
+        },
+        actions: w,
+        query: E,
+        history: p,
+      };
+    },
+    [w, E, v, m, p]
+  );
+}
+function K(t, e, n) {
+  var r = Object.keys(t()).reduce(function (n, r) {
+    var i;
+    return B(
+      B({}, n),
+      (((i = {})[r] = function () {
+        for (var n, i = [], o = 0; o < arguments.length; o++)
+          i[o] = arguments[o];
+        return (n = t(e()))[r].apply(n, i);
+      }),
+      i)
+    );
+  }, {});
+  return B(B({}, r), {
+    history: {
+      canUndo: function () {
+        return n.canUndo();
+      },
+      canRedo: function () {
+        return n.canRedo();
+      },
+    },
+  });
+}
+n(), r();
+var Q = (function () {
+    function t(t) {
+      (this.subscribers = []), (this.getState = t);
+    }
+    return (
+      (t.prototype.subscribe = function (t, e, n) {
+        var r = this,
+          i = new V(
+            function () {
+              return t(r.getState());
+            },
+            e,
+            n
+          );
+        return this.subscribers.push(i), this.unsubscribe.bind(this, i);
+      }),
+      (t.prototype.unsubscribe = function (t) {
+        if (this.subscribers.length) {
+          var e = this.subscribers.indexOf(t);
+          if (e > -1) return this.subscribers.splice(e, 1);
+        }
+      }),
+      (t.prototype.notify = function () {
+        this.subscribers.forEach(function (t) {
+          return t.collect();
+        });
+      }),
+      t
+    );
+  })(),
+  V = (function () {
+    function t(t, e, n) {
+      void 0 === n && (n = !1),
+        (this.collector = t),
+        (this.onChange = e),
+        n && this.collect();
+    }
+    return (
+      (t.prototype.collect = function () {
+        try {
+          var t = this.collector();
+          o(t, this.collected) ||
+            ((this.collected = t),
+            this.onChange && this.onChange(this.collected));
+        } catch (t) {
+          console.warn(t);
+        }
+      }),
+      t
+    );
+  })(),
+  X = function (t) {
+    var e = t.getBoundingClientRect(),
+      n = e.x,
+      r = e.y,
+      i = e.top,
+      o = e.left,
+      a = e.bottom,
+      s = e.right,
+      c = e.width,
+      u = e.height,
+      l = window.getComputedStyle(t),
+      p = {
+        left: parseInt(l.marginLeft),
+        right: parseInt(l.marginRight),
+        bottom: parseInt(l.marginBottom),
+        top: parseInt(l.marginTop),
+      },
+      f = {
+        left: parseInt(l.paddingLeft),
+        right: parseInt(l.paddingRight),
+        bottom: parseInt(l.paddingBottom),
+        top: parseInt(l.paddingTop),
+      };
+    return {
+      x: n,
+      y: r,
+      top: i,
+      left: o,
+      bottom: a,
+      right: s,
+      width: c,
+      height: u,
+      outerWidth: Math.round(c + p.left + p.right),
+      outerHeight: Math.round(u + p.top + p.bottom),
+      margin: p,
+      padding: f,
+      inFlow:
+        t.parentElement &&
+        !!(function (e) {
+          var n = getComputedStyle(e);
+          if (
+            !(
+              (l.overflow && 'visible' !== l.overflow) ||
+              'none' !== n.float ||
+              'grid' === n.display ||
+              ('flex' === n.display && 'column' !== n['flex-direction'])
+            )
+          ) {
+            switch (l.position) {
+              case 'static':
+              case 'relative':
+                break;
+              default:
+                return;
+            }
+            switch (t.tagName) {
+              case 'TR':
+              case 'TBODY':
+              case 'THEAD':
+              case 'TFOOT':
+                return !0;
+            }
+            switch (l.display) {
+              case 'block':
+              case 'list-item':
+              case 'table':
+              case 'flex':
+              case 'grid':
+                return !0;
+            }
+          }
+        })(t.parentElement),
+    };
+  };
+function Z(t, e) {
+  var n = t.subscribe,
+    r = t.getState,
+    i = t.actions,
+    o = t.query,
+    a = c(!0),
+    s = c(null),
+    f = c(e);
+  f.current = e;
+  var d = u(
+    function (t) {
+      return B(B({}, t), { actions: i, query: o });
+    },
+    [i, o]
+  );
+  a.current && e && ((s.current = e(r(), o)), (a.current = !1));
+  var h = p(d(s.current)),
+    y = h[0],
+    g = h[1];
+  return (
+    l(
+      function () {
+        var t;
+        return (
+          f.current &&
+            (t = n(
+              function (t) {
+                return f.current(t, o);
+              },
+              function (t) {
+                g(d(t));
+              }
+            )),
+          function () {
+            t && t();
+          }
+        );
+      },
+      [d, o, n]
+    ),
+    y
+  );
+}
+var $,
+  tt = y('1234567890abcdef', 24),
+  et = function () {
+    return tt();
+  },
+  nt = (function () {
+    function t() {
+      (this.isEnabled = !0),
+        (this.elementIdMap = new WeakMap()),
+        (this.registry = new Map());
+    }
+    return (
+      (t.prototype.getElementId = function (t) {
+        var e = this.elementIdMap.get(t);
+        if (e) return e;
+        var n = et();
+        return this.elementIdMap.set(t, n), n;
+      }),
+      (t.prototype.getConnectorId = function (t, e) {
+        return e + '--' + this.getElementId(t);
+      }),
+      (t.prototype.register = function (t, e) {
+        var n = this,
+          r = this.getByElement(t, e.name);
+        if (r) {
+          if (h(e.required, r.required)) return r;
+          this.getByElement(t, e.name).disable();
+        }
+        var i = null,
+          o = this.getConnectorId(t, e.name);
+        return (
+          this.registry.set(o, {
+            id: o,
+            required: e.required,
+            enable: function () {
+              i && i(), (i = e.connector(t, e.required, e.options));
+            },
+            disable: function () {
+              i && i();
+            },
+            remove: function () {
+              return n.remove(o);
+            },
+          }),
+          this.isEnabled && this.registry.get(o).enable(),
+          this.registry.get(o)
+        );
+      }),
+      (t.prototype.get = function (t) {
+        return this.registry.get(t);
+      }),
+      (t.prototype.remove = function (t) {
+        var e = this.get(t);
+        e && (e.disable(), this.registry.delete(e.id));
+      }),
+      (t.prototype.enable = function () {
+        (this.isEnabled = !0),
+          this.registry.forEach(function (t) {
+            t.enable();
+          });
+      }),
+      (t.prototype.disable = function () {
+        (this.isEnabled = !1),
+          this.registry.forEach(function (t) {
+            t.disable();
+          });
+      }),
+      (t.prototype.getByElement = function (t, e) {
+        return this.get(this.getConnectorId(t, e));
+      }),
+      (t.prototype.removeByElement = function (t, e) {
+        return this.remove(this.getConnectorId(t, e));
+      }),
+      (t.prototype.clear = function () {
+        this.disable(),
+          (this.elementIdMap = new WeakMap()),
+          (this.registry = new Map());
+      }),
+      t
+    );
+  })();
+!(function (t) {
+  (t[(t.HandlerDisabled = 0)] = 'HandlerDisabled'),
+    (t[(t.HandlerEnabled = 1)] = 'HandlerEnabled');
+})($ || ($ = {}));
+var rt = (function () {
+    function t(t) {
+      (this.registry = new nt()),
+        (this.subscribers = new Set()),
+        (this.options = t);
+    }
+    return (
+      (t.prototype.listen = function (t) {
+        var e = this;
+        return (
+          this.subscribers.add(t),
+          function () {
+            return e.subscribers.delete(t);
+          }
+        );
+      }),
+      (t.prototype.disable = function () {
+        this.onDisable && this.onDisable(),
+          this.registry.disable(),
+          this.subscribers.forEach(function (t) {
+            t($.HandlerDisabled);
+          });
+      }),
+      (t.prototype.enable = function () {
+        this.onEnable && this.onEnable(),
+          this.registry.enable(),
+          this.subscribers.forEach(function (t) {
+            t($.HandlerEnabled);
+          });
+      }),
+      (t.prototype.cleanup = function () {
+        this.disable(), this.subscribers.clear(), this.registry.clear();
+      }),
+      (t.prototype.addCraftEventListener = function (t, e, n, r) {
+        var i = function (r) {
+          (function (t, e, n) {
+            t.craft ||
+              (t.craft = {
+                stopPropagation: function () {},
+                blockedEvents: {},
+              });
+            for (
+              var r = (t.craft && t.craft.blockedEvents[e]) || [], i = 0;
+              i < r.length;
+              i++
+            ) {
+              var o = r[i];
+              if (n !== o && n.contains(o)) return !0;
+            }
+            return !1;
+          })(r, e, t) ||
+            ((r.craft.stopPropagation = function () {
+              r.craft.blockedEvents[e] || (r.craft.blockedEvents[e] = []),
+                r.craft.blockedEvents[e].push(t);
+            }),
+            n(r));
+        };
+        return (
+          t.addEventListener(e, i, r),
+          function () {
+            return t.removeEventListener(e, i, r);
+          }
+        );
+      }),
+      (t.prototype.createConnectorsUsage = function () {
+        var t = this,
+          e = this.handlers(),
+          n = new Set(),
+          r = !1,
+          i = new Map();
+        return {
+          connectors: Object.entries(e).reduce(function (e, o) {
+            var a,
+              s = o[0],
+              c = o[1];
+            return B(
+              B({}, e),
+              (((a = {})[s] = function (e, o, a) {
+                var u = function () {
+                  var r = t.registry.register(e, {
+                    required: o,
+                    name: s,
+                    options: a,
+                    connector: c,
+                  });
+                  return n.add(r.id), r;
+                };
+                return i.set(t.registry.getConnectorId(e, s), u), r && u(), e;
+              }),
+              a)
+            );
+          }, {}),
+          register: function () {
+            (r = !0),
+              i.forEach(function (t) {
+                t();
+              });
+          },
+          cleanup: function () {
+            (r = !1),
+              n.forEach(function (e) {
+                return t.registry.remove(e);
+              });
+          },
+        };
+      }),
+      (t.prototype.derive = function (t, e) {
+        return new t(this, e);
+      }),
+      (t.prototype.createProxyHandlers = function (t, e) {
+        var n = [],
+          r = t.handlers();
+        return (
+          e(
+            new Proxy(r, {
+              get: function (t, e, i) {
+                return e in r == 0
+                  ? Reflect.get(t, e, i)
+                  : function (t) {
+                      for (var i = [], o = 1; o < arguments.length; o++)
+                        i[o - 1] = arguments[o];
+                      var a = r[e].apply(r, W([t], i));
+                      a && n.push(a);
+                    };
+              },
+            })
+          ),
+          function () {
+            n.forEach(function (t) {
+              t();
+            });
+          }
+        );
+      }),
+      (t.prototype.reflect = function (t) {
+        return this.createProxyHandlers(this, t);
+      }),
+      t
+    );
+  })(),
+  it = (function (t) {
+    function e(e, n) {
+      var r = t.call(this, n) || this;
+      return (
+        (r.derived = e),
+        (r.options = n),
+        (r.unsubscribeParentHandlerListener = r.derived.listen(function (t) {
+          switch (t) {
+            case $.HandlerEnabled:
+              return r.enable();
+            case $.HandlerDisabled:
+              return r.disable();
+            default:
+              return;
+          }
+        })),
+        r
+      );
+    }
+    return (
+      (function (t, e) {
+        if ('function' != typeof e && null !== e)
+          throw new TypeError(
+            'Class extends value ' + String(e) + ' is not a constructor or null'
+          );
+        function n() {
+          this.constructor = t;
+        }
+        Y(t, e),
+          (t.prototype =
+            null === e
+              ? Object.create(e)
+              : ((n.prototype = e.prototype), new n()));
+      })(e, t),
+      (e.prototype.inherit = function (t) {
+        return this.createProxyHandlers(this.derived, t);
+      }),
+      (e.prototype.cleanup = function () {
+        t.prototype.cleanup.call(this), this.unsubscribeParentHandlerListener();
+      }),
+      e
+    );
+  })(rt);
+function ot(t, e) {
+  e && ('function' == typeof t ? t(e) : (t.current = e));
+}
+function at(t, e) {
+  var n = t.ref;
+  return (
+    g(
+      'string' != typeof n,
+      'Cannot connect to an element with an existing string ref. Please convert it to use a callback ref instead, or wrap it into a <span> or <div>. Read more: https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute'
+    ),
+    f(
+      t,
+      n
+        ? {
+            ref: function (t) {
+              ot(n, t), ot(e, t);
+            },
+          }
+        : { ref: e }
+    )
+  );
+}
+function st(t) {
+  if ('string' != typeof t.type) throw new Error();
+}
+function ct(t) {
+  return function (e) {
+    void 0 === e && (e = null);
+    for (var n = [], r = 1; r < arguments.length; r++) n[r - 1] = arguments[r];
+    if (!d(e)) {
+      if (!e) return;
+      var i = e;
+      return i && t.apply(void 0, W([i], n)), i;
+    }
+    var o = e;
+    return st(o), at(o, t);
+  };
+}
+function ut(t) {
+  return Object.keys(t).reduce(function (e, n) {
+    return (
+      (e[n] = ct(function () {
+        for (var e = [], r = 0; r < arguments.length; r++) e[r] = arguments[r];
+        return t[n].apply(t, e);
+      })),
+      e
+    );
+  }, {});
+}
+var lt = function (t) {
+    var e = t.parentDom,
+      n = a.createElement('div', {
+        style: B(
+          {
+            position: 'fixed',
+            display: 'block',
+            opacity: 1,
+            borderStyle: 'solid',
+            borderWidth: '1px',
+            borderColor: 'transparent',
+            zIndex: 99999,
+          },
+          t.style
+        ),
+      });
+    return e && e.ownerDocument !== document
+      ? m.createPortal(n, e.ownerDocument.body)
+      : n;
+  },
+  pt = function (t) {
+    l(t, []);
+  },
+  ft = function (t, e) {
+    var n =
+        'Deprecation warning: ' + t + ' will be deprecated in future relases.',
+      r = e.suggest,
+      i = e.doc;
+    r && (n += ' Please use ' + r + ' instead.'),
+      i && (n += '(' + i + ')'),
+      console.warn(n);
+  },
+  dt = function () {
+    return 'undefined' != typeof window;
+  },
+  ht = function () {
+    return dt() && /Linux/i.test(window.navigator.userAgent);
+  },
+  yt = function () {
+    return dt() && /Chrome/i.test(window.navigator.userAgent);
+  };
+export {
+  b as DEPRECATED_ROOT_NODE,
+  it as DerivedEventHandlers,
+  M as ERROR_CANNOT_DRAG,
+  _ as ERROR_DELETE_TOP_LEVEL_NODE,
+  U as ERROR_DESERIALIZE_COMPONENT_NOT_IN_RESOLVER,
+  w as ERROR_DUPLICATE_NODEID,
+  L as ERROR_INFINITE_CANVAS,
+  O as ERROR_INVALID_NODEID,
+  S as ERROR_INVALID_NODE_ID,
+  T as ERROR_MISSING_PLACEHOLDER_PLACEMENT,
+  C as ERROR_MOVE_CANNOT_DROP,
+  I as ERROR_MOVE_INCOMING_PARENT,
+  D as ERROR_MOVE_NONCANVAS_CHILD,
+  H as ERROR_MOVE_OUTGOING_PARENT,
+  N as ERROR_MOVE_ROOT_NODE,
+  x as ERROR_MOVE_TOP_LEVEL_NODE,
+  A as ERROR_MOVE_TO_DESCENDANT,
+  P as ERROR_MOVE_TO_NONCANVAS_PARENT,
+  E as ERROR_NOPARENT,
+  k as ERROR_NOT_IN_RESOLVER,
+  j as ERROR_RESOLVER_NOT_AN_OBJECT,
+  R as ERROR_TOP_LEVEL_ELEMENT_NO_ID,
+  q as ERROR_USE_EDITOR_OUTSIDE_OF_EDITOR_CONTEXT,
+  G as ERROR_USE_NODE_OUTSIDE_OF_EDITOR_CONTEXT,
+  $ as EventHandlerUpdates,
+  rt as EventHandlers,
+  z as HISTORY_ACTIONS,
+  F as History,
+  v as ROOT_NODE,
+  lt as RenderIndicator,
+  at as cloneWithRef,
+  K as createQuery,
+  ft as deprecationWarning,
+  X as getDOMInfo,
+  et as getRandomId,
+  yt as isChromium,
+  dt as isClientSide,
+  ht as isLinux,
+  Z as useCollector,
+  pt as useEffectOnce,
+  J as useMethods,
+  ut as wrapConnectorHooks,
+  ct as wrapHookToRecognizeElement,
+};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@craftjs/utils",
   "description": "Utilities used internally across the craft.js monorepo",
+  "type": "module",
   "version": "0.2.0-beta.8",
   "author": "Prev Wong <prevwong@gmail.com>",
   "license": "MIT",
-  "main": "./src/index.ts",
-  "module": "./src/index.ts",
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
     "start": "cross-env NODE_ENV=development ../../scripts/build.sh",
@@ -21,7 +22,8 @@
     "tiny-invariant": "^1.0.6"
   },
   "devDependencies": {
-    "@types/react": "17.0.2"
+    "@types/react": "17.0.2",
+    "cross-env": "^7.0.3"
   },
   "nohoist": [
     "immer",

--- a/packages/utils/rollup.config.js
+++ b/packages/utils/rollup.config.js
@@ -1,4 +1,4 @@
-import config from '../../rollup.config';
+import config from '../../rollup.config.js';
 
 export default {
   ...config,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,6 +1792,7 @@ __metadata:
   dependencies:
     "@craftjs/utils": "workspace:*"
     "@types/react": 17.0.2
+    cross-env: ^7.0.3
     debounce: ^1.2.0
     lodash: ^4.17.20
     react: 17.0.2
@@ -1822,6 +1823,7 @@ __metadata:
   resolution: "@craftjs/utils@workspace:packages/utils"
   dependencies:
     "@types/react": 17.0.2
+    cross-env: ^7.0.3
     immer: ^9.0.6
     lodash: ^4.17.20
     nanoid: ^3.1.23
@@ -3880,6 +3882,118 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.17.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-android-arm64@npm:4.17.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.17.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-darwin-x64@npm:4.17.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.17.2"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.17.2"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.17.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.17.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.17.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.17.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.17.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.17.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.17.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.17.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.17.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.17.2":
+  version: 4.17.2
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.17.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@samverschueren/stream-to-observable@npm:^0.3.0":
   version: 0.3.1
   resolution: "@samverschueren/stream-to-observable@npm:0.3.1"
@@ -4330,6 +4444,13 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@types/estree@npm:1.0.5"
+  checksum: dd8b5bed28e6213b7acd0fb665a84e693554d850b0df423ac8076cc3ad5823a6bc26b0251d080bdc545af83179ede51dd3f6fa78cad2c46ed1f29624ddf3e41a
   languageName: node
   linkType: hard
 
@@ -7787,6 +7908,18 @@ clsx@latest:
   languageName: node
   linkType: hard
 
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: ^7.0.1
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
+  languageName: node
+  linkType: hard
+
 "cross-fetch@npm:^3.0.4":
   version: 3.1.4
   resolution: "cross-fetch@npm:3.1.4"
@@ -7796,7 +7929,7 @@ clsx@latest:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -10688,6 +10821,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"fsevents@npm:~2.3.2":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: latest
+  checksum: 11e6ea6fea15e42461fc55b4b0e4a0a3c654faa567f1877dbd353f39156f69def97a69936d1746619d656c4b93de2238bf731f6085a03a50cabf287c9d024317
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@patch:fsevents@^1.2.7#~builtin<compat/fsevents>":
   version: 1.2.9
   resolution: "fsevents@patch:fsevents@npm%3A1.2.9#~builtin<compat/fsevents>::version=1.2.9&hash=18f3a7"
@@ -10701,6 +10844,15 @@ fsevents@^1.2.7:
 "fsevents@patch:fsevents@~2.3.1#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  dependencies:
+    node-gyp: latest
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#~builtin<compat/fsevents>::version=2.3.3&hash=18f3a7"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -20297,6 +20449,69 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.17.2":
+  version: 4.17.2
+  resolution: "rollup@npm:4.17.2"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": 4.17.2
+    "@rollup/rollup-android-arm64": 4.17.2
+    "@rollup/rollup-darwin-arm64": 4.17.2
+    "@rollup/rollup-darwin-x64": 4.17.2
+    "@rollup/rollup-linux-arm-gnueabihf": 4.17.2
+    "@rollup/rollup-linux-arm-musleabihf": 4.17.2
+    "@rollup/rollup-linux-arm64-gnu": 4.17.2
+    "@rollup/rollup-linux-arm64-musl": 4.17.2
+    "@rollup/rollup-linux-powerpc64le-gnu": 4.17.2
+    "@rollup/rollup-linux-riscv64-gnu": 4.17.2
+    "@rollup/rollup-linux-s390x-gnu": 4.17.2
+    "@rollup/rollup-linux-x64-gnu": 4.17.2
+    "@rollup/rollup-linux-x64-musl": 4.17.2
+    "@rollup/rollup-win32-arm64-msvc": 4.17.2
+    "@rollup/rollup-win32-ia32-msvc": 4.17.2
+    "@rollup/rollup-win32-x64-msvc": 4.17.2
+    "@types/estree": 1.0.5
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-powerpc64le-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: e6a2813fea25ea816ce582a04c2ffccc0b841ddc22842325c39353620214055bf827e0d7f6714e836170079faf0443ffc27966ccae27900ae3baa039aa36a8e1
+  languageName: node
+  linkType: hard
+
 "root-workspace-0b6124@workspace:.":
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
@@ -20336,6 +20551,7 @@ resolve@1.1.7:
     prettier: 2.0.1
     pretty-quick: 2.0.1
     rimraf: 3.0.2
+    rollup: ^4.17.2
     rollup-plugin-babel: 4.3.3
     rollup-plugin-commonjs: 10.1.0
     rollup-plugin-node-resolve: 5.2.0


### PR DESCRIPTION
## Goal
"publish" this package so Vite's local dev server added [here](https://github.com/kizen/react-app/pull/5829) only has one file to serve for each library instead of many. There was an issue like this https://github.com/vitejs/vite/issues/3301. React context was simply not working (always returning the default value). This doesn't fix the problem - just gets around it. It's not really worth fixing since you shouldn't need to load TypeScript source files from `node_modules` like we were doing (that was a change by us since it was the fastest way to run edits within this fork).

From now on changes to this repo will need to be built and checked in for the changes to take effect in the consuming apps.
1. Run `yarn build` from the workspaces with changes (`packages/core`, `packages/utils`).
2. This will overwrite `dist/esm/index.js` - commit those changes.

https://kizen.atlassian.net/browse/KZN-10702